### PR TITLE
Add new API for release body value

### DIFF
--- a/src/main/groovy/wooga/gradle/github/publish/GithubPublishSpec.groovy
+++ b/src/main/groovy/wooga/gradle/github/publish/GithubPublishSpec.groovy
@@ -57,9 +57,17 @@ interface GithubPublishSpec extends GithubSpec {
 
     GithubPublishSpec setBody(Object body)
 
+    GithubPublishSpec setBody(Closure closure)
+
+    GithubPublishSpec setBody(PublishBodyStrategy bodyStrategy)
+
     GithubPublishSpec body(String body)
 
     GithubPublishSpec body(Object body)
+
+    GithubPublishSpec body(Closure bodyStrategy)
+
+    GithubPublishSpec body(PublishBodyStrategy bodyStrategy)
 
     boolean isPrerelease()
 

--- a/src/main/groovy/wooga/gradle/github/publish/PublishBodyStrategy.groovy
+++ b/src/main/groovy/wooga/gradle/github/publish/PublishBodyStrategy.groovy
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package wooga.gradle.github.publish
+
+import org.kohsuke.github.GHRepository
+
+interface PublishBodyStrategy {
+    String getBody(GHRepository repository)
+}


### PR DESCRIPTION
Description
===========
The `body` value for a release can be set lazy via `clojure`. This pull
requests adds two additional API methods for the `body` parameter

**PublishBodyStrategy**
```groovy

def publishBodyStrategy = newwooga.gradle.github.publish.PublishBodyStrategy() {
    @Override
    String getBody(org.kohsuke.github.GHRepository ghRepository) {
       return ghRepository.name
    }
}

testPublish.body(publishBodyStrategy)
```

-or-

**closure with parameter**
```groovy

testPublish.body({repo -> repo.name})
```

This allows to access the current repo to be published to before
constructing the release body.