### PR TITLE
 abstract GitHub task

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,39 @@ githubPublish {
 }
 ```
 
+## Generic Github Task
+
+The type `wooga.gradle.github.base.Github` can be used to build generic tasks who can access the github API through [github-api.kohsuke.org][github-api]. It implements the `wooga.gradle.github.base.GithubSpec` interface and handles the basic github client creation and authentication.
+The task type is usable for scripted tasks or can be extended. You should then use `wooga.gradle.github.base.AbstractGithubTask` instead.
+Along with the properties from `wooga.gradle.github.base.GithubSpec` the task gives access to [`client`](http://github-api.kohsuke.org/apidocs/org/kohsuke/github/GitHub.html) and, if `repositoryName` is set, to [`repository`](http://github-api.kohsuke.org/apidocs/org/kohsuke/github/GHRepository.html) property.
+
+**create repos**
+```
+task customGithubTask(type:wooga.gradle.github.base.Github) {
+    doLast {
+        def builder = client.createRepository("Repo")
+        builder.description("description")
+        builder.autoInit(false)
+        builder.licenseTemplate('MIT')
+        builder.private_(false)
+        builder.issues(false)
+        builder.wiki(false)
+        builder.create()
+    }
+}
+```
+
+**update files**
+```
+task customGithubTask(type:wooga.gradle.github.base.Github) {
+    doLast {
+        def content = repository.getFileContent("$file")
+        content.update("$updatedContent", "update release notes")
+    }
+}
+```
+
+
 Gradle and Java Compatibility
 =============================
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ github {
     userName = "wooga"
     password = "a password."
     token "a github access token"
-    repository "wooga/atlas-github"
+    repositoryName "wooga/atlas-github"
     baseUrl = null
 }
 
@@ -40,7 +40,7 @@ githubPublish {
     userName = "wooga"
     password = "a password."
     token "a github access token"
-    repository "wooga/atlas-github"
+    repositoryName "wooga/atlas-github"
     baseUrl = null
     targetCommitish = "master"
     tagName = project.version

--- a/src/integrationTest/groovy/wooga/gradle/github/GithubAuthenticationIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/github/GithubAuthenticationIntegrationSpec.groovy
@@ -26,7 +26,7 @@ class GithubAuthenticationIntegrationSpec extends GithubPublishIntegration {
 
     def setup() {
         buildFile << """
-            github.repository = "$testRepositoryName"
+            github.repositoryName = "$testRepositoryName"
 
             task testPublish(type:wooga.gradle.github.publish.GithubPublish) {
                 from "releaseAssets"

--- a/src/integrationTest/groovy/wooga/gradle/github/GithubIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/github/GithubIntegrationSpec.groovy
@@ -1,0 +1,142 @@
+package wooga.gradle.github
+
+import java.nio.charset.StandardCharsets
+
+class GithubIntegrationSpec extends GithubPublishIntegrationWithDefaultAuth {
+
+    def setup() {
+        buildFile << """
+            import wooga.gradle.github.base.Github
+            github.repositoryName = "$testRepositoryName"
+
+            task customGithubTask(type:Github)
+        """.stripIndent()
+    }
+
+    def "executes github tasks without failure when actions are empty"() {
+        expect:
+        runTasksSuccessfully("customGithubTask")
+    }
+
+    def "can access repository from action"() {
+        given: "a action inside customGithubTask which makes API calls with the repository object"
+
+        buildFile << """
+            customGithubTask {
+                doLast {
+                    println("this is the current repo name " + repository.full_name)
+                }
+            }
+        """.stripIndent()
+
+        when:
+        def result = runTasksSuccessfully("customGithubTask")
+
+        then:
+        result.standardOutput.contains("this is the current repo name " + testRepositoryName)
+    }
+
+    def "can call API calls with repository object from action"() {
+        given: "a action inside customGithubTask which makes API calls with the repository object"
+        buildFile << """
+            customGithubTask {
+                doLast {
+                    repository.createLabel("TestLabel", "ffffff")
+                }
+            }
+        """.stripIndent()
+
+        when:
+        runTasksSuccessfully("customGithubTask")
+
+        then:
+        def l = testRepo.getLabel("TestLabel")
+
+        cleanup:
+        l.delete()
+    }
+
+    def "can update files and content of repository"() {
+        given: "a test file in the created repo"
+        testRepo.createContent(initialContent, "add empty release notes", file)
+
+
+        and: "an action inside customGithubTask which changes this new file"
+        buildFile << """
+            customGithubTask {
+                doLast {
+                    def content = repository.getFileContent("$file")
+                    content.update("$updatedContent", "update release notes")
+                }
+            }
+        """.stripIndent()
+
+        when:
+        runTasksSuccessfully("customGithubTask")
+
+        then:
+        def content = testRepo.getFileContent(file)
+        InputStream contentStream = content.read()
+        InputStreamReader contentStreamReader = new InputStreamReader(contentStream, StandardCharsets.UTF_8)
+        contentStreamReader.text == updatedContent
+
+        cleanup:
+        content.delete("delete release notes")
+
+        where:
+        file = "RELEASE_NOTES.md"
+        initialContent = "## EMPTY RELEASE NOTES"
+        updatedContent = "## Initial Release"
+    }
+
+    def "can access github client object"() {
+        given: "an action inside customGithubTask which creates a new repo"
+        buildFile << """
+            customGithubTask {
+                doLast {
+                    def builder = client.createRepository("$customRepositoryName".split('/')[1])
+                    builder.description("$description")
+                    builder.autoInit(false)
+                    builder.licenseTemplate('MIT')
+                    builder.private_(false)
+                    builder.issues(false)
+                    builder.wiki(false)
+                    builder.create()
+                }
+            }
+        """.stripIndent()
+
+        and:
+        maybeDelete(customRepositoryName)
+
+        when:
+        runTasksSuccessfully("customGithubTask")
+
+        then:
+        def customRepo = client.getRepository(customRepositoryName)
+        customRepo.description == description
+
+        cleanup:
+        maybeDelete(customRepositoryName)
+
+        where:
+        customRepositoryName = testRepositoryName + "_custom"
+        description = "Custom repo created via gradle"
+    }
+
+    def "fails when repo is not available"() {
+        given: "a buildfile with publish task and non existing repo"
+        buildFile << """
+            customGithubTask {
+                repositoryName = "${testUserName}/customRepo"
+                doLast {
+                    repository.full_name
+                }
+            }
+        """
+
+        expect:
+        def result = runTasksWithFailure("customGithubTask")
+        result.standardError.contains("can't find repository $testUserName/customRepo")
+    }
+}

--- a/src/integrationTest/groovy/wooga/gradle/github/GithubPublishIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/github/GithubPublishIntegrationSpec.groovy
@@ -17,6 +17,8 @@
 
 package wooga.gradle.github
 
+import spock.lang.Unroll
+
 class GithubPublishIntegrationSpec extends GithubPublishIntegrationWithDefaultAuth {
 
     def "task creates just the release when asset source is empty"() {
@@ -39,7 +41,73 @@ class GithubPublishIntegrationSpec extends GithubPublishIntegrationWithDefaultAu
         tagName = "v0.1.0-GithubPublishIntegrationSpec"
     }
 
-    def "use copy spec for GithubPlublish task configuration"() {
+    @Unroll
+    def "can use PatternFilterable API to configure task #method #filter"() {
+        given: "some test files to publish"
+        File sources = new File(projectDir, "sources")
+        sources.mkdirs()
+
+        def file1 = createFile("fileOne", sources)
+        file1 << """test"""
+
+        def file2 = createFile("fileTwo", sources)
+        file2 << """YO"""
+
+        def file3 = createFile("fileThree", sources)
+        file3 << """YO"""
+
+        def file4 = createFile("fileFour", sources)
+        file4 << """YO"""
+
+        def file5 = createFile("fileFive", sources)
+        file5 << """YO"""
+
+        def file6 = createFile("fileSix", sources)
+        file6 << """YO"""
+
+        def file7 = createFile("fileSeven", sources)
+        file7 << """YO"""
+
+        def file8 = createFile("fileEight", sources)
+        file8 << """YO"""
+
+        def file9 = createFile("fileNine", sources)
+        file9 << """YO"""
+
+        and: "a buildfile with publish task"
+        buildFile << """
+            task testPublish(type:wooga.gradle.github.publish.GithubPublish) {
+                from "sources"
+                ${method}($filter)             
+                tagName = "$tagName"
+
+                println(getExcludes())
+                println(getIncludes())
+            }
+        """
+
+        when:
+        runTasksSuccessfully("testPublish")
+
+        then:
+        def release = getRelease(tagName)
+        def assets = release.assets
+        assets.size() == 1
+        assets.any { it.name == "fileNine" }
+
+        where:
+        method    | filter
+        "exclude" | "'*One', '*T*', '*S*', '*F*', '*E*'"
+        "exclude" | "{it.file in fileTree(dir:'sources', excludes:['*Nine']).files}"
+        "exclude" | "['*One', '*T*', '*S*', '*F*', '*E*']"
+        "include" | "'*Nine'"
+        "include" | "{it.file in fileTree(dir:'sources', excludes:['*One', '*T*', '*S*', '*F*', '*E*']).files}"
+        "include" | "['*Nine']"
+
+        tagName = "v0.1.1-GithubPublishIntegrationSpec"
+    }
+
+    def "can use CopySourceSpec API to configure task"() {
         given: "some test files to publish"
         File sources = new File(projectDir, "sources")
         sources.mkdirs()

--- a/src/integrationTest/groovy/wooga/gradle/github/GithubPublishIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/github/GithubPublishIntegrationSpec.groovy
@@ -116,7 +116,7 @@ class GithubPublishIntegrationSpec extends GithubPublishIntegrationWithDefaultAu
         buildFile << """
             task testPublish(type:wooga.gradle.github.publish.GithubPublish) {
                 from "fileToPublish"
-                repository = "${testUserName}/customRepo"
+                repositoryName = "${testUserName}/customRepo"
                 tagName = "test"
             }
         """

--- a/src/integrationTest/groovy/wooga/gradle/github/GithubPublishIntegrationWithDefaultAuth.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/github/GithubPublishIntegrationWithDefaultAuth.groovy
@@ -23,7 +23,7 @@ abstract class GithubPublishIntegrationWithDefaultAuth extends GithubPublishInte
         buildFile << """
             github {
                 userName = "$testUserName"
-                repository = "$testRepositoryName"
+                repositoryName = "$testRepositoryName"
                 token = "$testUserToken"
             }
         """.stripIndent()

--- a/src/integrationTest/groovy/wooga/gradle/github/GithubPublishPropertySpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/github/GithubPublishPropertySpec.groovy
@@ -54,7 +54,7 @@ class GithubPublishPropertySpec extends GithubPublishIntegration {
             task testPublish(type:wooga.gradle.github.publish.GithubPublish) {
                 from "releaseAssets"
                 tagName = "$tagName"
-                repository = "$testRepositoryName"
+                repositoryName = "$testRepositoryName"
                 token = "$testUserToken"
             }            
         """.stripIndent()
@@ -161,7 +161,7 @@ class GithubPublishPropertySpec extends GithubPublishIntegration {
             task testPublish(type:wooga.gradle.github.publish.GithubPublish) {
                 from "releaseAssets"
                 tagName = "$tagName"
-                repository = "$testRepositoryName"
+                repositoryName = "$testRepositoryName"
                 token = "$testUserToken"
             }            
         """.stripIndent()
@@ -204,7 +204,7 @@ class GithubPublishPropertySpec extends GithubPublishIntegration {
             task testPublish(type:wooga.gradle.github.publish.GithubPublish) {
                 from "releaseAssets"
                 tagName = "$tagName"
-                repository = "$testRepositoryName"
+                repositoryName = "$testRepositoryName"
                 token = "$testUserToken"
             }            
         """.stripIndent()
@@ -246,7 +246,7 @@ class GithubPublishPropertySpec extends GithubPublishIntegration {
             task testPublish(type:wooga.gradle.github.publish.GithubPublish) {
                 from "releaseAssets"
                 tagName = "$tagName"
-                repository = "$testRepositoryName"
+                repositoryName = "$testRepositoryName"
                 token = "$testUserToken"
             }            
         """.stripIndent()
@@ -291,7 +291,7 @@ class GithubPublishPropertySpec extends GithubPublishIntegration {
             task testPublish(type:wooga.gradle.github.publish.GithubPublish) {
                 from "releaseAssets"
                 tagName = "$tagName"
-                repository = "$testRepositoryName"
+                repositoryName = "$testRepositoryName"
                 token = "$testUserToken"
             }            
         """.stripIndent()
@@ -349,7 +349,7 @@ class GithubPublishPropertySpec extends GithubPublishIntegration {
                 $methodName("$baseUrl")
                 tagName = "$tagName"
                 draft = false
-                repository = "$testRepositoryName"
+                repositoryName = "$testRepositoryName"
                 token = "$testUserToken"
             }            
         """.stripIndent()
@@ -372,7 +372,7 @@ class GithubPublishPropertySpec extends GithubPublishIntegration {
     }
 
     @Unroll
-    def "can set repository with #methodName"() {
+    def "can set repositoryName with #methodName"() {
         given: "files to publish"
         createTestAssetsToPublish(1)
 
@@ -398,7 +398,7 @@ class GithubPublishPropertySpec extends GithubPublishIntegration {
 
         where:
         useSetter << [true, false]
-        methodName = useSetter ? "setRepository" : "repository"
+        methodName = useSetter ? "setRepositoryName" : "repositoryName"
         tagName = "v0.2.${Math.abs(new Random().nextInt() % 1000) + 1}-GithubPublishPropertySpec"
         versionName = tagName.replaceFirst('v', '')
     }
@@ -416,7 +416,7 @@ class GithubPublishPropertySpec extends GithubPublishIntegration {
                 from "releaseAssets"
                 $methodName($preValue "$tagNameValue" $postValue)
                 draft = false
-                repository = "$testRepositoryName"
+                repositoryName = "$testRepositoryName"
                 token = "$testUserToken"
             }            
         """.stripIndent()
@@ -475,7 +475,7 @@ class GithubPublishPropertySpec extends GithubPublishIntegration {
         "'https://github.com/owner/invalid.git'" | true      | "Repository value $repoName is not a valid github repository name"
         "'https://github.com/owner/invalid.git'" | false     | "Repository value $repoName is not a valid github repository name"
 
-        methodName = useSetter ? "setRepository" : "repository"
+        methodName = useSetter ? "setRepositoryName" : "repositoryName"
     }
 
     @Unroll
@@ -491,7 +491,7 @@ class GithubPublishPropertySpec extends GithubPublishIntegration {
                 from "releaseAssets"
                 tagName = "v0.1.0"
                 $methodName($token)
-                repository = "$testRepositoryName"
+                repositoryName = "$testRepositoryName"
                 
             }            
         """.stripIndent()
@@ -523,7 +523,7 @@ class GithubPublishPropertySpec extends GithubPublishIntegration {
                 from "releaseAssets"
                 tagName = "v0.1.0"
                 $methodName($url)
-                repository = "$testRepositoryName"
+                repositoryName = "$testRepositoryName"
                 
             }            
         """.stripIndent()
@@ -551,7 +551,7 @@ class GithubPublishPropertySpec extends GithubPublishIntegration {
             task testPublish(type:wooga.gradle.github.publish.GithubPublish) {
                 from "releaseAssets"
                 tagName = "v0.1    .0"
-                repository = "$testRepositoryName"
+                repositoryName = "$testRepositoryName"
                 token = "$testUserToken"
                 
             }            

--- a/src/main/groovy/wooga/gradle/github/base/AbstractGithubTask.groovy
+++ b/src/main/groovy/wooga/gradle/github/base/AbstractGithubTask.groovy
@@ -1,0 +1,167 @@
+package wooga.gradle.github.base
+
+import org.gradle.api.GradleException
+import org.gradle.api.internal.ConventionTask
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.Optional
+import org.kohsuke.github.GHRepository
+import org.kohsuke.github.GitHub
+import org.kohsuke.github.GitHubBuilder
+
+abstract class AbstractGithubTask<T extends AbstractGithubTask> extends ConventionTask implements GithubSpec {
+
+    private String repository
+    private String baseUrl
+    private String userName
+    private String password
+    private String token
+
+    private GitHub client
+
+    private final Class<T> taskType
+
+    AbstractGithubTask(Class<T> taskType) {
+        this.taskType = taskType
+    }
+
+    protected GitHub getClient() {
+        if(!this.client) {
+            def builder = new GitHubBuilder()
+
+            if (getUserName() && getPassword()) {
+                builder = builder.withPassword(getUserName(), getPassword())
+            } else if (getUserName() && getToken()) {
+                builder = builder.withOAuthToken(getToken(), getUserName())
+
+            } else if (getToken()) {
+                builder = builder.withOAuthToken(getToken())
+
+            } else {
+                builder = GitHubBuilder.fromCredentials()
+            }
+
+            if (getBaseUrl()) {
+                builder = builder.withEndpoint(getBaseUrl())
+            }
+
+            this.client = builder.build()
+        }
+
+        return client
+    }
+
+    GHRepository getRepository(GitHub client) {
+        GHRepository repository
+        try {
+            repository = client.getRepository(getRepository())
+        }
+        catch (Exception e) {
+            throw new GradleException("can't find repository ${getRepository()}")
+        }
+        repository
+    }
+
+    @Override
+    String getRepository() {
+        return repository
+    }
+
+    @Override
+    T setRepository(String repository) {
+        if (repository == null || repository.isEmpty()) {
+            throw new IllegalArgumentException("repository")
+        }
+
+        if (!GithubRepositoryValidator.validateRepositoryName(repository)) {
+            throw new IllegalArgumentException("Repository value '$repository' is not a valid github repository name. Expecting `owner/repo`.")
+        }
+
+        this.repository = repository
+        return taskType.cast(this)
+    }
+
+    @Override
+    T repository(String repo) {
+        return taskType.cast(this.setRepository(repo))
+    }
+
+    @Optional
+    @Input
+    @Override
+    String getBaseUrl() {
+        return baseUrl
+    }
+
+    @Override
+    T setBaseUrl(String baseUrl) {
+        if (baseUrl == null || baseUrl.isEmpty()) {
+            throw new IllegalArgumentException("baseUrl")
+        }
+        this.baseUrl = baseUrl
+        return taskType.cast(this)
+    }
+
+    @Override
+    T baseUrl(String baseUrl) {
+        return taskType.cast(this.setBaseUrl(baseUrl))
+    }
+
+    @Optional
+    @Input
+    @Override
+    String getToken() {
+        return this.token
+    }
+
+    @Override
+    T setToken(String token) {
+        if (token == null || token.isEmpty()) {
+            throw new IllegalArgumentException("token")
+        }
+        this.token = token
+        return taskType.cast(this)
+    }
+
+    @Override
+    T token(String token) {
+        return taskType.cast(this.setToken(token))
+    }
+
+    @Optional
+    @Input
+    @Override
+    String getUserName() {
+        return this.userName
+    }
+
+    @Override
+    T setUserName(String userName) {
+        this.userName = userName
+        return taskType.cast(this)
+    }
+
+    @Override
+    T userName(String userName) {
+        this.setUserName(userName)
+        return taskType.cast(this)
+    }
+
+    @Optional
+    @Input
+    @Override
+    String getPassword() {
+        return this.password
+    }
+
+    @Override
+    T setPassword(String password) {
+        this.password = password
+        return taskType.cast(this)
+    }
+
+    @Override
+    T password(String password) {
+        this.setPassword(password)
+        return taskType.cast(this)
+    }
+}

--- a/src/main/groovy/wooga/gradle/github/base/AbstractGithubTask.groovy
+++ b/src/main/groovy/wooga/gradle/github/base/AbstractGithubTask.groovy
@@ -61,6 +61,17 @@ abstract class AbstractGithubTask<T extends AbstractGithubTask> extends Conventi
         repository
     }
 
+    GHRepository getRepository() {
+        GHRepository repository
+        try {
+            repository = getClient().getRepository(getRepositoryName())
+        }
+        catch (Exception e) {
+            throw new GradleException("can't find repository ${getRepositoryName()}")
+        }
+        repository
+    }
+
     @Override
     String getRepositoryName() {
         return repositoryName

--- a/src/main/groovy/wooga/gradle/github/base/AbstractGithubTask.groovy
+++ b/src/main/groovy/wooga/gradle/github/base/AbstractGithubTask.groovy
@@ -10,7 +10,7 @@ import org.kohsuke.github.GitHubBuilder
 
 abstract class AbstractGithubTask<T extends AbstractGithubTask> extends ConventionTask implements GithubSpec {
 
-    private String repository
+    private String repositoryName
     private String baseUrl
     private String userName
     private String password
@@ -53,36 +53,36 @@ abstract class AbstractGithubTask<T extends AbstractGithubTask> extends Conventi
     GHRepository getRepository(GitHub client) {
         GHRepository repository
         try {
-            repository = client.getRepository(getRepository())
+            repository = client.getRepository(getRepositoryName())
         }
         catch (Exception e) {
-            throw new GradleException("can't find repository ${getRepository()}")
+            throw new GradleException("can't find repository ${getRepositoryName()}")
         }
         repository
     }
 
     @Override
-    String getRepository() {
-        return repository
+    String getRepositoryName() {
+        return repositoryName
     }
 
     @Override
-    T setRepository(String repository) {
-        if (repository == null || repository.isEmpty()) {
+    T setRepositoryName(String name) {
+        if (name == null || name.isEmpty()) {
             throw new IllegalArgumentException("repository")
         }
 
-        if (!GithubRepositoryValidator.validateRepositoryName(repository)) {
-            throw new IllegalArgumentException("Repository value '$repository' is not a valid github repository name. Expecting `owner/repo`.")
+        if (!GithubRepositoryValidator.validateRepositoryName(name)) {
+            throw new IllegalArgumentException("Repository value '$name' is not a valid github repository name. Expecting `owner/repo`.")
         }
 
-        this.repository = repository
+        this.repositoryName = name
         return taskType.cast(this)
     }
 
     @Override
-    T repository(String repo) {
-        return taskType.cast(this.setRepository(repo))
+    T repositoryName(String name) {
+        return taskType.cast(this.setRepositoryName(name))
     }
 
     @Optional

--- a/src/main/groovy/wooga/gradle/github/base/DefaultGithubPluginExtention.groovy
+++ b/src/main/groovy/wooga/gradle/github/base/DefaultGithubPluginExtention.groovy
@@ -17,15 +17,13 @@
 
 package wooga.gradle.github.base
 
-import org.gradle.api.Project
-
 class DefaultGithubPluginExtention implements GithubPluginExtention {
     static final String GITHUB_USER_NAME_OPTION = "github.userName"
     static final String GITHUB_USER_PASSWORD_OPTION = "github.password"
     static final String GITHUB_TOKEN_OPTION = "github.token"
     static final String GITHUB_REPOSITORY_OPTION = "github.repository"
 
-    private String repository
+    private String repositoryName
     private String baseUrl
 
     private String userName
@@ -87,9 +85,9 @@ class DefaultGithubPluginExtention implements GithubPluginExtention {
     }
 
     @Override
-    String getRepository() {
-        String value = this.repository
-        if (!this.repository && properties[GITHUB_REPOSITORY_OPTION]) {
+    String getRepositoryName() {
+        String value = this.repositoryName
+        if (!this.repositoryName && properties[GITHUB_REPOSITORY_OPTION]) {
             value = properties[GITHUB_REPOSITORY_OPTION]
         }
 
@@ -101,22 +99,22 @@ class DefaultGithubPluginExtention implements GithubPluginExtention {
     }
 
     @Override
-    DefaultGithubPluginExtention setRepository(String repository) {
-        if (repository == null || repository.isEmpty()) {
+    DefaultGithubPluginExtention setRepositoryName(String name) {
+        if (name == null || name.isEmpty()) {
             throw new IllegalArgumentException("repository")
         }
 
-        if (!GithubRepositoryValidator.validateRepositoryName(repository)) {
-            throw new IllegalArgumentException("Repository value '$repository' is not a valid github repository name. Expecting `owner/repo`.")
+        if (!GithubRepositoryValidator.validateRepositoryName(name)) {
+            throw new IllegalArgumentException("Repository value '$name' is not a valid github repository name. Expecting `owner/repo`.")
         }
 
-        this.repository = repository
+        this.repositoryName = name
         return this
     }
 
     @Override
-    DefaultGithubPluginExtention repository(String repo) {
-        return setRepository(repo)
+    DefaultGithubPluginExtention repositoryName(String name) {
+        return setRepositoryName(name)
     }
 
     @Override

--- a/src/main/groovy/wooga/gradle/github/base/Github.groovy
+++ b/src/main/groovy/wooga/gradle/github/base/Github.groovy
@@ -1,0 +1,8 @@
+package wooga.gradle.github.base
+
+class Github extends AbstractGithubTask {
+
+    Github() {
+        super(Github.class)
+    }
+}

--- a/src/main/groovy/wooga/gradle/github/base/GithubBasePlugin.groovy
+++ b/src/main/groovy/wooga/gradle/github/base/GithubBasePlugin.groovy
@@ -53,14 +53,6 @@ class GithubBasePlugin implements Plugin<Project> {
                 taskConventionMapping.map("userName", { extention.getUserName() })
                 taskConventionMapping.map("password", { extention.getPassword() })
                 taskConventionMapping.map("token", { extention.getToken() })
-
-                task.onlyIf(new Spec<Task>() {
-                    @Override
-                    boolean isSatisfiedBy(Task t) {
-                        AbstractGithubTask publishTask = (AbstractGithubTask) t
-                        return publishTask.repositoryName != null
-                    }
-                })
             }
         })
     }

--- a/src/main/groovy/wooga/gradle/github/base/GithubBasePlugin.groovy
+++ b/src/main/groovy/wooga/gradle/github/base/GithubBasePlugin.groovy
@@ -49,7 +49,7 @@ class GithubBasePlugin implements Plugin<Project> {
                 ConventionMapping taskConventionMapping = task.getConventionMapping()
 
                 taskConventionMapping.map("baseUrl", { extention.getBaseUrl() })
-                taskConventionMapping.map("repository", { extention.getRepository() })
+                taskConventionMapping.map("repositoryName", { extention.getRepositoryName() })
                 taskConventionMapping.map("userName", { extention.getUserName() })
                 taskConventionMapping.map("password", { extention.getPassword() })
                 taskConventionMapping.map("token", { extention.getToken() })
@@ -58,7 +58,7 @@ class GithubBasePlugin implements Plugin<Project> {
                     @Override
                     boolean isSatisfiedBy(Task t) {
                         AbstractGithubTask publishTask = (AbstractGithubTask) t
-                        return publishTask.repository != null
+                        return publishTask.repositoryName != null
                     }
                 })
             }

--- a/src/main/groovy/wooga/gradle/github/base/GithubSpec.groovy
+++ b/src/main/groovy/wooga/gradle/github/base/GithubSpec.groovy
@@ -38,11 +38,11 @@ interface GithubSpec {
 
     GithubSpec token(String token)
 
-    String getRepository()
+    String getRepositoryName()
 
-    GithubSpec setRepository(String repo)
+    GithubSpec setRepositoryName(String name)
 
-    GithubSpec repository(String repo)
+    GithubSpec repositoryName(String name)
 
     String getBaseUrl()
 

--- a/src/main/groovy/wooga/gradle/github/publish/GithubPublish.groovy
+++ b/src/main/groovy/wooga/gradle/github/publish/GithubPublish.groovy
@@ -30,10 +30,12 @@ import org.gradle.api.file.FileTreeElement
 import org.gradle.api.logging.Logger
 import org.gradle.api.logging.Logging
 import org.gradle.api.specs.Spec
+import org.gradle.api.specs.Specs
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.TaskAction
 import org.gradle.api.tasks.WorkResult
+import org.gradle.util.ConfigureUtil
 import org.kohsuke.github.*
 import org.zeroturnaround.zip.ZipUtil
 import wooga.gradle.github.base.AbstractGithubTask
@@ -175,8 +177,7 @@ class GithubPublish extends AbstractGithubTask implements GithubPublishSpec {
 
     @Override
     GithubPublish from(Object sourcePath, Closure configureClosure) {
-        assetsCopySpec.from(sourcePath, configureClosure)
-        processAssets = true
+        this.from(sourcePath, ConfigureUtil.configureUsing(configureClosure))
         return this
     }
 
@@ -217,8 +218,7 @@ class GithubPublish extends AbstractGithubTask implements GithubPublishSpec {
 
     @Override
     GithubPublish include(Iterable<String> includes) {
-        assetsCopySpec.include(includes)
-        return this
+        return this.setIncludes(includes)
     }
 
     @Override
@@ -229,8 +229,7 @@ class GithubPublish extends AbstractGithubTask implements GithubPublishSpec {
 
     @Override
     GithubPublish include(Closure includeSpec) {
-        assetsCopySpec.include(includeSpec)
-        return this
+        return this.include(Specs.<FileTreeElement>convertClosureToSpec(includeSpec))
     }
 
     @Override
@@ -241,8 +240,7 @@ class GithubPublish extends AbstractGithubTask implements GithubPublishSpec {
 
     @Override
     GithubPublish exclude(Iterable<String> excludes) {
-        assetsCopySpec.exclude(excludes)
-        return this
+        return this.setExcludes(excludes)
     }
 
     @Override
@@ -253,8 +251,7 @@ class GithubPublish extends AbstractGithubTask implements GithubPublishSpec {
 
     @Override
     GithubPublish exclude(Closure excludeSpec) {
-        assetsCopySpec.exclude(excludeSpec)
-        return this
+        return this.exclude(Specs.<FileTreeElement>convertClosureToSpec(excludeSpec))
     }
 
     private Object tagName

--- a/src/main/groovy/wooga/gradle/github/publish/GithubPublishPlugin.groovy
+++ b/src/main/groovy/wooga/gradle/github/publish/GithubPublishPlugin.groovy
@@ -20,10 +20,8 @@ package wooga.gradle.github.publish
 import org.gradle.api.Action
 import org.gradle.api.Plugin
 import org.gradle.api.Project
-import org.gradle.api.Task
 import org.gradle.api.internal.ConventionMapping
 import org.gradle.api.publish.plugins.PublishingPlugin
-import org.gradle.api.specs.Spec
 import org.gradle.api.tasks.TaskContainer
 import wooga.gradle.github.base.GithubBasePlugin
 import wooga.gradle.github.base.GithubPluginExtention
@@ -50,7 +48,7 @@ class GithubPublishPlugin implements Plugin<Project> {
 
     private void createDefaultPublishTask() {
         def githubPublish = tasks.create(name: PUBLISH_TASK_NAME, type: GithubPublish, group: GithubBasePlugin.GROUP)
-        githubPublish.description = "Publish artifacts to github releases"
+        githubPublish.description = "Publish github release"
         tasks.getByName(PublishingPlugin.PUBLISH_LIFECYCLE_TASK_NAME).dependsOn githubPublish
     }
 
@@ -60,24 +58,11 @@ class GithubPublishPlugin implements Plugin<Project> {
             void execute(GithubPublish task) {
                 ConventionMapping taskConventionMapping = task.getConventionMapping()
 
-                taskConventionMapping.map("baseUrl", { extention.getBaseUrl() })
-                taskConventionMapping.map("repository", { extention.getRepository() })
-                taskConventionMapping.map("userName", { extention.getUserName() })
-                taskConventionMapping.map("password", { extention.getPassword() })
-                taskConventionMapping.map("token", { extention.getToken() })
                 taskConventionMapping.map("targetCommitish", { "master" })
                 taskConventionMapping.map("prerelease", { false })
                 taskConventionMapping.map("draft", { false })
                 taskConventionMapping.map("tagName", { project.version.toString() })
                 taskConventionMapping.map("releaseName", { project.version.toString() })
-
-                task.onlyIf(new Spec<Task>() {
-                    @Override
-                    boolean isSatisfiedBy(Task t) {
-                        GithubPublish publishTask = (GithubPublish) t
-                        return publishTask.repository != null
-                    }
-                })
             }
         })
     }

--- a/src/main/groovy/wooga/gradle/github/publish/GithubPublishPlugin.groovy
+++ b/src/main/groovy/wooga/gradle/github/publish/GithubPublishPlugin.groovy
@@ -20,8 +20,10 @@ package wooga.gradle.github.publish
 import org.gradle.api.Action
 import org.gradle.api.Plugin
 import org.gradle.api.Project
+import org.gradle.api.Task
 import org.gradle.api.internal.ConventionMapping
 import org.gradle.api.publish.plugins.PublishingPlugin
+import org.gradle.api.specs.Spec
 import org.gradle.api.tasks.TaskContainer
 import wooga.gradle.github.base.GithubBasePlugin
 import wooga.gradle.github.base.GithubPluginExtention
@@ -63,6 +65,14 @@ class GithubPublishPlugin implements Plugin<Project> {
                 taskConventionMapping.map("draft", { false })
                 taskConventionMapping.map("tagName", { project.version.toString() })
                 taskConventionMapping.map("releaseName", { project.version.toString() })
+
+                task.onlyIf(new Spec<Task>() {
+                    @Override
+                    boolean isSatisfiedBy(Task t) {
+                        GithubPublish publishTask = (GithubPublish) t
+                        return publishTask.repositoryName != null
+                    }
+                })
             }
         })
     }

--- a/src/main/groovy/wooga/gradle/github/publish/GithubPublishSpec.groovy
+++ b/src/main/groovy/wooga/gradle/github/publish/GithubPublishSpec.groovy
@@ -17,9 +17,11 @@
 
 package wooga.gradle.github.publish
 
+import org.gradle.api.file.CopySourceSpec
+import org.gradle.api.tasks.util.PatternFilterable
 import wooga.gradle.github.base.GithubSpec
 
-interface GithubPublishSpec extends GithubSpec {
+interface GithubPublishSpec extends GithubSpec, CopySourceSpec, PatternFilterable {
 
     String getTagName()
 

--- a/src/test/groovy/wooga/gradle/github/base/DefaultGithubPluginExtentionSpec.groovy
+++ b/src/test/groovy/wooga/gradle/github/base/DefaultGithubPluginExtentionSpec.groovy
@@ -57,8 +57,8 @@ class DefaultGithubPluginExtentionSpec extends Specification {
             token == tokenValue
             getToken() == tokenValue
 
-            repository == repositoryValue
-            getRepository() == repositoryValue
+            repositoryName == repositoryValue
+            getRepositoryName() == repositoryValue
         }
 
         where:
@@ -75,16 +75,16 @@ class DefaultGithubPluginExtentionSpec extends Specification {
         }
 
         when:
-        extension.repository
+        extension.repositoryName
 
         then:
         IllegalArgumentException e = thrown()
         e.message.contains("Repository value '$propertyValue' is not a valid github repository name")
 
         where:
-        valueToTest  | propertyKey                                           | propertyValue
-        "repository" | DefaultGithubPluginExtention.GITHUB_REPOSITORY_OPTION | "invalid-repo-name"
-        "repository" | DefaultGithubPluginExtention.GITHUB_REPOSITORY_OPTION | "https://github.com/some/repo"
+        valueToTest      | propertyKey                                           | propertyValue
+        "repositoryName" | DefaultGithubPluginExtention.GITHUB_REPOSITORY_OPTION | "invalid-repo-name"
+        "repositoryName" | DefaultGithubPluginExtention.GITHUB_REPOSITORY_OPTION | "https://github.com/some/repo"
     }
 
     @Unroll("#methodName throws IllegalArgumentException when value is #propertyMessage")
@@ -112,12 +112,12 @@ class DefaultGithubPluginExtentionSpec extends Specification {
     }
 
     @Unroll("#methodName throws IllegalArgumentException when value is #propertyMessage")
-    def "repository setter throws IllegalArgumentException"() {
+    def "repositoryName setter throws IllegalArgumentException"() {
         when:
         if (useSetter) {
-            extension.setRepository(propertyValue)
+            extension.setRepositoryName(propertyValue)
         } else {
-            extension.repository(propertyValue)
+            extension.repositoryName(propertyValue)
         }
 
         then:
@@ -136,12 +136,12 @@ class DefaultGithubPluginExtentionSpec extends Specification {
     }
 
     @Unroll("#methodName throws IllegalArgumentException when value is #propertyMessage")
-    def "repository setter throws IllegalArgumentException when passing invalid repo"() {
+    def "repositoryName setter throws IllegalArgumentException when passing invalid repo"() {
         when:
         if (useSetter) {
-            extension.setRepository(propertyValue)
+            extension.setRepositoryName(propertyValue)
         } else {
-            extension.repository(propertyValue)
+            extension.repositoryName(propertyValue)
         }
 
         then:
@@ -240,7 +240,7 @@ class DefaultGithubPluginExtentionSpec extends Specification {
                 setUserName("userName")
                 setPassword("password")
                 setToken("token")
-                setRepository("test/repository")
+                setRepositoryName("test/repository")
             }
 
         } else {
@@ -249,7 +249,7 @@ class DefaultGithubPluginExtentionSpec extends Specification {
                 userName("userName")
                 password("password")
                 token("token")
-                repository("test/repository")
+                repositoryName("test/repository")
             }
         }
 
@@ -259,7 +259,7 @@ class DefaultGithubPluginExtentionSpec extends Specification {
             userName == "userName"
             password == "password"
             token == "token"
-            repository == "test/repository"
+            repositoryName == "test/repository"
         }
 
 

--- a/src/test/groovy/wooga/gradle/github/base/GithubRepositoryValidatorSpec.groovy
+++ b/src/test/groovy/wooga/gradle/github/base/GithubRepositoryValidatorSpec.groovy
@@ -23,12 +23,12 @@ import spock.lang.Unroll
 class GithubRepositoryValidatorSpec extends Specification {
 
     @Unroll
-    def "validates repository value #repository correctly"() {
+    def "validates repositoryName value #repository correctly"() {
         expect:
-        isValid == GithubRepositoryValidator.validateRepositoryName(repository)
+        isValid == GithubRepositoryValidator.validateRepositoryName(repositoryName)
 
         where:
-        repository                     | isValid
+        repositoryName                 | isValid
         "user/repo"                    | true
         null                           | false
         "https://github.com/user/repo" | false


### PR DESCRIPTION
## Description

### Add AbstractGithubTask and refactor GithubPublish

The `GithubPublish` task used to extend `Copy` to leverage the copy
logic for asset preparation during task execution. To create an
`abstract` base task I needed to get rid of this inheritance. The task
implements `CopySpecs` sub interfaces (`CopySourceSpec`,
`PatternFilterable`) needed to function as before. All github
authentication related logic and properties are located at
`AbstractGithubTask` This makes it possible to create other tasks with
the basic authentication setup.

### Change propertyName repository to repositoryName

This change was needed to have a clear naming scheme when handling with
github repository names and API objects

### Add generic Github gradle task type

This task allows the user to issue github API calls to the provided
repository. It also exposes the `GHClient` object to do other API
related jobs.

**create repos**
```
customGithubTask {
    doLast {
        def builder =client.createRepository("Repo")
        builder.description("description")
        builder.autoInit(false)
        builder.licenseTemplate('MIT')
        builder.private_(false)
        builder.issues(false)
        builder.wiki(false)
        builder.create()
    }
}
```

**update files**
```
customGithubTask {
    doLast {
        def content = repository.getFileContent("$file")
        content.update("$updatedContent", "update release notes")
    }
}
```



