### PR TITLE
Fix draft github release when release has no assets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ gradle-app.setting
 # # Work around https://youtrack.jetbrains.com/issue/IDEA-116898
 # gradle/wrapper/gradle-wrapper.properties
 userHome/
+out

--- a/src/integrationTest/groovy/wooga/gradle/github/GithubPublishAssetsIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/github/GithubPublishAssetsIntegrationSpec.groovy
@@ -45,6 +45,7 @@ class GithubPublishAssetsIntegrationSpec extends GithubPublishIntegrationWithDef
 
         then:
         def release = getRelease(tagName)
+        !release.isDraft()
         def assets = release.assets
         assets.size() == 1
         assets.any { it.name == "package.zip" }
@@ -80,6 +81,7 @@ class GithubPublishAssetsIntegrationSpec extends GithubPublishIntegrationWithDef
 
         then:
         def release = getRelease(tagName)
+        !release.isDraft()
         def assets = release.assets
         assets.size() == 1
         assets.any { it.name == "package.zip" }
@@ -120,6 +122,7 @@ class GithubPublishAssetsIntegrationSpec extends GithubPublishIntegrationWithDef
 
         then:
         def release = getRelease(tagName)
+        !release.isDraft()
         def assets = release.assets
         assets.size() == 4
         assets.every() { it.name =~ /fileToPublish\d\.json/ }
@@ -162,6 +165,7 @@ class GithubPublishAssetsIntegrationSpec extends GithubPublishIntegrationWithDef
 
         then:
         def release = getRelease(tagName)
+        !release.isDraft()
         def assets = release.assets
         assets.size() == 2
         assets.any { it.name == "package.zip" }

--- a/src/integrationTest/groovy/wooga/gradle/github/GithubPublishIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/github/GithubPublishIntegrationSpec.groovy
@@ -34,6 +34,7 @@ class GithubPublishIntegrationSpec extends GithubPublishIntegrationWithDefaultAu
 
         then:
         def release = getRelease(tagName)
+        !release.isDraft()
         def assets = release.assets
         assets.size() == 0
 
@@ -91,6 +92,7 @@ class GithubPublishIntegrationSpec extends GithubPublishIntegrationWithDefaultAu
 
         then:
         def release = getRelease(tagName)
+        !release.isDraft()
         def assets = release.assets
         assets.size() == 1
         assets.any { it.name == "fileNine" }
@@ -129,6 +131,7 @@ class GithubPublishIntegrationSpec extends GithubPublishIntegrationWithDefaultAu
 
         then:
         def release = getRelease(tagName)
+        !release.isDraft()
         def assets = release.assets
         assets.size() == 2
         assets.any { it.name == "fileOne" }
@@ -166,6 +169,7 @@ class GithubPublishIntegrationSpec extends GithubPublishIntegrationWithDefaultAu
 
         then:
         def release = getRelease(tagName)
+        !release.isDraft()
         def assets = release.assets
         assets.size() == 2
         assets.any { it.name == "one.zip" }
@@ -239,6 +243,7 @@ class GithubPublishIntegrationSpec extends GithubPublishIntegrationWithDefaultAu
 
         then:
         def release = getRelease(tagName)
+        !release.isDraft()
         def assets = release.assets
         assets.size() == 1
         assets.any { it.name == "fileToPublish.json" }


### PR DESCRIPTION
## Description

When creating a release with no assets configured to upload, the release will be a draft only release because the last steps to mark the release as done are not executed. This change will add more assertions to the specs to make sure that a complete release is never a `draft` and changes the logic to create a non draft release right from the start when no assets are provided.

resolve #8

## Changes

![FIX] release logic and mark release as non draft in all cases
![ADD] `!isDraft()` assertions to test specs

[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:http://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:http://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:http://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://resources.atlas.wooga.com/icons/icon_webGL.svg "Web:GL"
