### PR TITLE
Add groovydoc

### DIFF
--- a/docs/Tasks.md
+++ b/docs/Tasks.md
@@ -2,13 +2,13 @@
 
 | Task name          | Depends on            | Type                                           | Description |
 | ------------------ | --------------------- | ---------------------------------------------- | ----------- |
-| githubPublish      |                       | `wooga.gradle.github.publish.GithubPublish`    | Copies files and folder configured to temp directory and uploads them to github release |
+| githubPublish      |                       | `wooga.gradle.github.publish.tasks.GithubPublish`    | Copies files and folder configured to temp directory and uploads them to github release |
 
 The plugin will only add one task `githubPublish` which needs further configuration before it executes.
 
 ## Authentication
 To authenticate with [github] you need to set either the `userName` and `token` parameter in the `github` plugin extension or in the `GithubPublish` task configuration.
-If you specify the values in the extension configuration all tasks of type `wooga.gradle.github.publish.GithubPublish` will be configured with these values by default. You can create multiple publish tasks with different credentials or repository values.
+If you specify the values in the extension configuration all tasks of type `wooga.gradle.github.publish.tasks.GithubPublish` will be configured with these values by default. You can create multiple publish tasks with different credentials or repository values.
 You can also use [github-api.kohsuke.org][github-api] authentication fallback logic [fromCredentials][github-cred-auth] or [fromEnvironment][github-env-auth].
 
 **kohsuke api docs fromEnvironment**
@@ -88,13 +88,13 @@ githubPublish {
 
 ## Generic Github Task
 
-The type `wooga.gradle.github.base.Github` can be used to build generic tasks who can access the github API through [github-api.kohsuke.org][github-api]. It implements the `wooga.gradle.github.base.GithubSpec` interface and handles the basic github client creation and authentication.
-The task type is usable for scripted tasks or can be extended. You should then use `wooga.gradle.github.base.AbstractGithubTask` instead.
+The type `wooga.gradle.github.base.tasks.Github` can be used to build generic tasks who can access the github API through [github-api.kohsuke.org][github-api]. It implements the `wooga.gradle.github.base.GithubSpec` interface and handles the basic github client creation and authentication.
+The task type is usable for scripted tasks or can be extended. You should then use `wooga.gradle.github.base.tasks.internal.AbstractGithubTask` instead.
 Along with the properties from `wooga.gradle.github.base.GithubSpec` the task gives access to [`client`](http://github-api.kohsuke.org/apidocs/org/kohsuke/github/GitHub.html) and, if `repositoryName` is set, to [`repository`](http://github-api.kohsuke.org/apidocs/org/kohsuke/github/GHRepository.html) property.
 
 **create repos**
 ```
-task customGithubTask(type:wooga.gradle.github.base.Github) {
+task customGithubTask(type:wooga.gradle.github.base.tasks.Github) {
     doLast {
         def builder = client.createRepository("Repo")
         builder.description("description")
@@ -110,7 +110,7 @@ task customGithubTask(type:wooga.gradle.github.base.Github) {
 
 **update files**
 ```
-task customGithubTask(type:wooga.gradle.github.base.Github) {
+task customGithubTask(type:wooga.gradle.github.base.tasks.Github) {
     doLast {
         def content = repository.getFileContent("$file")
         content.update("$updatedContent", "update release notes")

--- a/docs/api/wooga/gradle/github/base/AbstractGithubTask.html
+++ b/docs/api/wooga/gradle/github/base/AbstractGithubTask.html
@@ -91,7 +91,7 @@ if (location.href.indexOf('is-external=true') == -1) {
 </div>
 <div class="contentContainer">
 <ul class="inheritance">
-<li><ul class="inheritance"></ul></li><li><ul class="inheritance"></ul></li><li><ul class="inheritance"></ul></li><li><ul class="inheritance"></ul></li><li>wooga.gradle.github.base.AbstractGithubTask
+<li><ul class="inheritance"></ul></li><li><ul class="inheritance"></ul></li><li><ul class="inheritance"></ul></li><li><ul class="inheritance"></ul></li><li>wooga.gradle.github.base.tasks.internal.AbstractGithubTask
 </ul>
 <div class="description">
     <ul class="blockList">

--- a/docs/api/wooga/gradle/github/base/DefaultGithubPluginExtention.html
+++ b/docs/api/wooga/gradle/github/base/DefaultGithubPluginExtention.html
@@ -91,7 +91,7 @@ if (location.href.indexOf('is-external=true') == -1) {
 </div>
 <div class="contentContainer">
 <ul class="inheritance">
-<li><ul class="inheritance"></ul></li><li>wooga.gradle.github.base.DefaultGithubPluginExtention
+<li><ul class="inheritance"></ul></li><li>wooga.gradle.github.base.internal.DefaultGithubPluginExtension
 </ul>
 <div class="description">
     <ul class="blockList">

--- a/docs/api/wooga/gradle/github/base/Github.html
+++ b/docs/api/wooga/gradle/github/base/Github.html
@@ -91,7 +91,7 @@ if (location.href.indexOf('is-external=true') == -1) {
 </div>
 <div class="contentContainer">
 <ul class="inheritance">
-<li><ul class="inheritance"></ul></li><li><ul class="inheritance"></ul></li><li><ul class="inheritance"></ul></li><li><ul class="inheritance"></ul></li><li><ul class="inheritance"></ul></li><li>wooga.gradle.github.base.Github
+<li><ul class="inheritance"></ul></li><li><ul class="inheritance"></ul></li><li><ul class="inheritance"></ul></li><li><ul class="inheritance"></ul></li><li><ul class="inheritance"></ul></li><li>wooga.gradle.github.base.tasks.Github
 </ul>
 <div class="description">
     <ul class="blockList">

--- a/docs/api/wooga/gradle/github/base/GithubRepositoryValidator.html
+++ b/docs/api/wooga/gradle/github/base/GithubRepositoryValidator.html
@@ -91,7 +91,7 @@ if (location.href.indexOf('is-external=true') == -1) {
 </div>
 <div class="contentContainer">
 <ul class="inheritance">
-<li><ul class="inheritance"></ul></li><li>wooga.gradle.github.base.GithubRepositoryValidator
+<li><ul class="inheritance"></ul></li><li>wooga.gradle.github.base.internal.GithubRepositoryValidator
 </ul>
 <div class="description">
     <ul class="blockList">

--- a/docs/api/wooga/gradle/github/publish/GithubPublish.html
+++ b/docs/api/wooga/gradle/github/publish/GithubPublish.html
@@ -91,7 +91,7 @@ if (location.href.indexOf('is-external=true') == -1) {
 </div>
 <div class="contentContainer">
 <ul class="inheritance">
-<li><ul class="inheritance"></ul></li><li><ul class="inheritance"></ul></li><li><ul class="inheritance"></ul></li><li><ul class="inheritance"></ul></li><li><ul class="inheritance"></ul></li><li>wooga.gradle.github.publish.GithubPublish
+<li><ul class="inheritance"></ul></li><li><ul class="inheritance"></ul></li><li><ul class="inheritance"></ul></li><li><ul class="inheritance"></ul></li><li><ul class="inheritance"></ul></li><li>wooga.gradle.github.publish.tasks.GithubPublish
 </ul>
 <div class="description">
     <ul class="blockList">

--- a/src/integrationTest/groovy/wooga/gradle/github/GithubAuthenticationIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/github/GithubAuthenticationIntegrationSpec.groovy
@@ -62,10 +62,10 @@ class GithubAuthenticationIntegrationSpec extends GithubPublishIntegration {
 
         where:
         accessParams                                                                         | authMethod
-        "userName = '${testUserName}'; password = '${testUserToken}'"                        | "username/password"
-        "userName = '${testUserName}'; token = '${testUserToken}'"                           | "username/token"
+        "username = '${testUserName}'; password = '${testUserToken}'"                        | "username/password"
+        "username = '${testUserName}'; token = '${testUserToken}'"                           | "username/token"
         "token = '${testUserToken}'"                                                         | "token"
-        "token('${testUserToken}').userName('${testUserName}').password('${testUserToken}')" | "username/password/token set with chained method"
+        "token('${testUserToken}').username('${testUserName}').password('${testUserToken}')" | "username/password/token set with chained method"
     }
 
     @Unroll
@@ -87,8 +87,8 @@ class GithubAuthenticationIntegrationSpec extends GithubPublishIntegration {
 
         where:
         accessParams                                                        | authMethod
-        "github.userName=${testUserName}\ngithub.password=${testUserToken}" | "username/password"
-        "github.userName=${testUserName}\ngithub.token=${testUserToken}"    | "username/token"
+        "github.username=${testUserName}\ngithub.password=${testUserToken}" | "username/password"
+        "github.username=${testUserName}\ngithub.token=${testUserToken}"    | "username/token"
         "github.token=${testUserToken}"                                     | "token"
     }
 

--- a/src/integrationTest/groovy/wooga/gradle/github/GithubAuthenticationIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/github/GithubAuthenticationIntegrationSpec.groovy
@@ -28,7 +28,7 @@ class GithubAuthenticationIntegrationSpec extends GithubPublishIntegration {
         buildFile << """
             github.repositoryName = "$testRepositoryName"
 
-            task testPublish(type:wooga.gradle.github.publish.GithubPublish) {
+            task testPublish(type:wooga.gradle.github.publish.tasks.GithubPublish) {
                 from "releaseAssets"
                 tagName = "v0.${Math.abs(new Random().nextInt() % 1000) + 1}.0-GithubAuthenticationIntegrationSpec"
             }

--- a/src/integrationTest/groovy/wooga/gradle/github/GithubIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/github/GithubIntegrationSpec.groovy
@@ -6,7 +6,7 @@ class GithubIntegrationSpec extends GithubPublishIntegrationWithDefaultAuth {
 
     def setup() {
         buildFile << """
-            import wooga.gradle.github.base.Github
+            import wooga.gradle.github.base.tasks.Github
             github.repositoryName = "$testRepositoryName"
 
             task customGithubTask(type:Github)

--- a/src/integrationTest/groovy/wooga/gradle/github/GithubPublishAssetsIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/github/GithubPublishAssetsIntegrationSpec.groovy
@@ -32,7 +32,7 @@ class GithubPublishAssetsIntegrationSpec extends GithubPublishIntegrationWithDef
 
         and: "a buildfile with publish task"
         buildFile << """
-            task testPublish(type:wooga.gradle.github.publish.GithubPublish) {
+            task testPublish(type:wooga.gradle.github.publish.tasks.GithubPublish) {
                 from("releaseAssets") {
                     into "package"
                 }
@@ -70,7 +70,7 @@ class GithubPublishAssetsIntegrationSpec extends GithubPublishIntegrationWithDef
 
         and: "a buildfile with publish task"
         buildFile << """
-            task testPublish(type:wooga.gradle.github.publish.GithubPublish) {
+            task testPublish(type:wooga.gradle.github.publish.tasks.GithubPublish) {
                 from "releaseAssets"
                 tagName = "$tagName"
             }
@@ -111,7 +111,7 @@ class GithubPublishAssetsIntegrationSpec extends GithubPublishIntegrationWithDef
                 githubAssets files("fileToPublish4.json")
             }
 
-            task testPublish(type:wooga.gradle.github.publish.GithubPublish) {
+            task testPublish(type:wooga.gradle.github.publish.tasks.GithubPublish) {
                 from configurations.githubAssets
                 tagName = "$tagName"
             }
@@ -154,7 +154,7 @@ class GithubPublishAssetsIntegrationSpec extends GithubPublishIntegrationWithDef
 
         and: "a buildfile with publish task"
         buildFile << """
-            task testPublish(type:wooga.gradle.github.publish.GithubPublish) {
+            task testPublish(type:wooga.gradle.github.publish.tasks.GithubPublish) {
                 from "releaseAssets"
                 tagName = "$tagName"
             }

--- a/src/integrationTest/groovy/wooga/gradle/github/GithubPublishIntegration.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/github/GithubPublishIntegration.groovy
@@ -31,7 +31,7 @@ class GithubPublishIntegration extends IntegrationSpec {
         if (env.containsKey(key)) {
             return env.get(key)
         }
-        return ""
+        ""
     }
 
     @Shared
@@ -109,7 +109,7 @@ class GithubPublishIntegration extends IntegrationSpec {
     }
 
     File createTestAssetsToPublish(int numberOfFiles) {
-        return createTestAssetsToPublish(numberOfFiles, null)
+        createTestAssetsToPublish(numberOfFiles, null)
     }
 
     File createTestAssetsToPublish(int numberOfFiles, String packageName) {
@@ -126,7 +126,7 @@ class GithubPublishIntegration extends IntegrationSpec {
             createFile("file${i}", packageDirectory) << "test content"
         }
 
-        return assets
+        assets
     }
 
     GHRelease getRelease(String tagName) {

--- a/src/integrationTest/groovy/wooga/gradle/github/GithubPublishIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/github/GithubPublishIntegrationSpec.groovy
@@ -24,7 +24,7 @@ class GithubPublishIntegrationSpec extends GithubPublishIntegrationWithDefaultAu
     def "task creates just the release when asset source is empty"() {
         given: "a buildfile with publish task"
         buildFile << """
-            task testPublish(type:wooga.gradle.github.publish.GithubPublish) {
+            task testPublish(type:wooga.gradle.github.publish.tasks.GithubPublish) {
                 tagName = "$tagName"
             }
         """
@@ -77,7 +77,7 @@ class GithubPublishIntegrationSpec extends GithubPublishIntegrationWithDefaultAu
 
         and: "a buildfile with publish task"
         buildFile << """
-            task testPublish(type:wooga.gradle.github.publish.GithubPublish) {
+            task testPublish(type:wooga.gradle.github.publish.tasks.GithubPublish) {
                 from "sources"
                 ${method}($filter)             
                 tagName = "$tagName"
@@ -120,7 +120,7 @@ class GithubPublishIntegrationSpec extends GithubPublishIntegrationWithDefaultAu
 
         and: "a buildfile with publish task"
         buildFile << """
-            task testPublish(type:wooga.gradle.github.publish.GithubPublish) {
+            task testPublish(type:wooga.gradle.github.publish.tasks.GithubPublish) {
                 from "sources"
                 tagName = "$tagName"
             }
@@ -152,7 +152,7 @@ class GithubPublishIntegrationSpec extends GithubPublishIntegrationWithDefaultAu
 
         and: "a buildfile with publish task"
         buildFile << """
-            task testPublish(type:wooga.gradle.github.publish.GithubPublish) {
+            task testPublish(type:wooga.gradle.github.publish.tasks.GithubPublish) {
                 from(project.file("sources")) {
                     into "one"
                 }
@@ -186,7 +186,7 @@ class GithubPublishIntegrationSpec extends GithubPublishIntegrationWithDefaultAu
 
         and: "a buildfile with publish task and non existing repo"
         buildFile << """
-            task testPublish(type:wooga.gradle.github.publish.GithubPublish) {
+            task testPublish(type:wooga.gradle.github.publish.tasks.GithubPublish) {
                 from "fileToPublish"
                 repositoryName = "${testUserName}/customRepo"
                 tagName = "test"
@@ -208,7 +208,7 @@ class GithubPublishIntegrationSpec extends GithubPublishIntegrationWithDefaultAu
 
         and: "a buildfile with publish task"
         buildFile << """
-            task testPublish(type:wooga.gradle.github.publish.GithubPublish) {
+            task testPublish(type:wooga.gradle.github.publish.tasks.GithubPublish) {
                 from "fileToPublish"
                 tagName = "$tagName"
             }
@@ -232,7 +232,7 @@ class GithubPublishIntegrationSpec extends GithubPublishIntegrationWithDefaultAu
 
         and: "a buildfile with publish task"
         buildFile << """
-            task testPublish(type:wooga.gradle.github.publish.GithubPublish) {
+            task testPublish(type:wooga.gradle.github.publish.tasks.GithubPublish) {
                 from "releaseAssets"
                 tagName = "$tagName"
             }

--- a/src/integrationTest/groovy/wooga/gradle/github/GithubPublishIntegrationWithDefaultAuth.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/github/GithubPublishIntegrationWithDefaultAuth.groovy
@@ -22,7 +22,7 @@ abstract class GithubPublishIntegrationWithDefaultAuth extends GithubPublishInte
     def setup() {
         buildFile << """
             github {
-                userName = "$testUserName"
+                username = "$testUserName"
                 repositoryName = "$testRepositoryName"
                 token = "$testUserToken"
             }

--- a/src/integrationTest/groovy/wooga/gradle/github/GithubPublishPropertySpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/github/GithubPublishPropertySpec.groovy
@@ -29,7 +29,7 @@ class GithubPublishPropertySpec extends GithubPublishIntegration {
 
         and: "a buildfile with publish task"
         buildFile << """
-            task testPublish(type:wooga.gradle.github.publish.GithubPublish) {
+            task testPublish(type:wooga.gradle.github.publish.tasks.GithubPublish) {
                 from "releaseAssets"
                 tagName = "v0.1.0"
             }
@@ -51,7 +51,7 @@ class GithubPublishPropertySpec extends GithubPublishIntegration {
         buildFile << """
             version "$versionName"
 
-            task testPublish(type:wooga.gradle.github.publish.GithubPublish) {
+            task testPublish(type:wooga.gradle.github.publish.tasks.GithubPublish) {
                 from "releaseAssets"
                 tagName = "$tagName"
                 repositoryName = "$testRepositoryName"
@@ -158,7 +158,7 @@ class GithubPublishPropertySpec extends GithubPublishIntegration {
         buildFile << """
             version "$versionName"
 
-            task testPublish(type:wooga.gradle.github.publish.GithubPublish) {
+            task testPublish(type:wooga.gradle.github.publish.tasks.GithubPublish) {
                 from "releaseAssets"
                 tagName = "$tagName"
                 repositoryName = "$testRepositoryName"
@@ -201,7 +201,7 @@ class GithubPublishPropertySpec extends GithubPublishIntegration {
         buildFile << """
             version "$versionName"
 
-            task testPublish(type:wooga.gradle.github.publish.GithubPublish) {
+            task testPublish(type:wooga.gradle.github.publish.tasks.GithubPublish) {
                 from "releaseAssets"
                 tagName = "$tagName"
                 repositoryName = "$testRepositoryName"
@@ -243,7 +243,7 @@ class GithubPublishPropertySpec extends GithubPublishIntegration {
         buildFile << """
             version "$versionName"
 
-            task testPublish(type:wooga.gradle.github.publish.GithubPublish) {
+            task testPublish(type:wooga.gradle.github.publish.tasks.GithubPublish) {
                 from "releaseAssets"
                 tagName = "$tagName"
                 repositoryName = "$testRepositoryName"
@@ -288,7 +288,7 @@ class GithubPublishPropertySpec extends GithubPublishIntegration {
         buildFile << """
             version "$versionName"
 
-            task testPublish(type:wooga.gradle.github.publish.GithubPublish) {
+            task testPublish(type:wooga.gradle.github.publish.tasks.GithubPublish) {
                 from "releaseAssets"
                 tagName = "$tagName"
                 repositoryName = "$testRepositoryName"
@@ -344,7 +344,7 @@ class GithubPublishPropertySpec extends GithubPublishIntegration {
         buildFile << """
             version "$versionName"
 
-            task testPublish(type:wooga.gradle.github.publish.GithubPublish) {
+            task testPublish(type:wooga.gradle.github.publish.tasks.GithubPublish) {
                 from "releaseAssets"
                 $methodName("$baseUrl")
                 tagName = "$tagName"
@@ -380,7 +380,7 @@ class GithubPublishPropertySpec extends GithubPublishIntegration {
         buildFile << """
             version "$versionName"
 
-            task testPublish(type:wooga.gradle.github.publish.GithubPublish) {
+            task testPublish(type:wooga.gradle.github.publish.tasks.GithubPublish) {
                 from "releaseAssets"
                 $methodName("$testRepositoryName")
                 tagName = "$tagName"
@@ -412,7 +412,7 @@ class GithubPublishPropertySpec extends GithubPublishIntegration {
         buildFile << """
             version "$versionName"
 
-            task testPublish(type:wooga.gradle.github.publish.GithubPublish) {
+            task testPublish(type:wooga.gradle.github.publish.tasks.GithubPublish) {
                 from "releaseAssets"
                 $methodName($preValue "$tagNameValue" $postValue)
                 draft = false
@@ -452,7 +452,7 @@ class GithubPublishPropertySpec extends GithubPublishIntegration {
         buildFile << """
             version "0.1.0"
 
-            task testPublish(type:wooga.gradle.github.publish.GithubPublish) {
+            task testPublish(type:wooga.gradle.github.publish.tasks.GithubPublish) {
                 from "releaseAssets"
                 tagName = "v0.1.0"
                 $methodName($repoName)
@@ -487,7 +487,7 @@ class GithubPublishPropertySpec extends GithubPublishIntegration {
         buildFile << """
             version "0.1.0"
 
-            task testPublish(type:wooga.gradle.github.publish.GithubPublish) {
+            task testPublish(type:wooga.gradle.github.publish.tasks.GithubPublish) {
                 from "releaseAssets"
                 tagName = "v0.1.0"
                 $methodName($token)
@@ -519,7 +519,7 @@ class GithubPublishPropertySpec extends GithubPublishIntegration {
         buildFile << """
             version "0.1.0"
 
-            task testPublish(type:wooga.gradle.github.publish.GithubPublish) {
+            task testPublish(type:wooga.gradle.github.publish.tasks.GithubPublish) {
                 from "releaseAssets"
                 tagName = "v0.1.0"
                 $methodName($url)
@@ -548,7 +548,7 @@ class GithubPublishPropertySpec extends GithubPublishIntegration {
 
         and: "a buildfile with publish task"
         buildFile << """
-            task testPublish(type:wooga.gradle.github.publish.GithubPublish) {
+            task testPublish(type:wooga.gradle.github.publish.tasks.GithubPublish) {
                 from "releaseAssets"
                 tagName = "v0.1    .0"
                 repositoryName = "$testRepositoryName"

--- a/src/integrationTest/groovy/wooga/gradle/github/GithubPublishPropertySpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/github/GithubPublishPropertySpec.groovy
@@ -327,7 +327,7 @@ class GithubPublishPropertySpec extends GithubPublishIntegration {
         publishBodyStrategy = new PublishBodyStrategy() {
             @Override
             String getBody(GHRepository ghRepository) {
-                return ghRepository.name
+                ghRepository.name
             }
         }
         tagName = "v0.1.${Math.abs(new Random().nextInt() % 1000) + 1}-GithubPublishPropertySpec"

--- a/src/main/groovy/wooga/gradle/github/GithubPlugin.groovy
+++ b/src/main/groovy/wooga/gradle/github/GithubPlugin.groovy
@@ -21,6 +21,37 @@ import org.gradle.api.Plugin
 import org.gradle.api.Project
 import wooga.gradle.github.publish.GithubPublishPlugin
 
+/**
+ * A {@link org.gradle.api.Plugin} which provides tasks and conventions to publish artifacts to github.
+ * <p>
+ * Example:
+ * <pre>
+ * {@code
+ *     plugins {
+ *         id "net.wooga.github" version "0.6.1"
+ *     }
+ *
+ *     github {
+ *         username = "wooga"
+ *         password = "a password."
+ *         token "a github access token"
+ *         repositoryName "wooga/atlas-github"
+ *         baseUrl = null
+ *     }
+ *
+ *     githubPublish {
+ *         targetCommitish = "master"
+ *         tagName = project.version
+ *         releaseName = project.version
+ *         body = "Release XYZ"
+ *         prerelease = false
+ *         draft = false
+ *
+ *         from(file('build/output'))
+ *     }
+ * }
+ * </pre>
+ */
 class GithubPlugin implements Plugin<Project> {
 
     @Override

--- a/src/main/groovy/wooga/gradle/github/GithubPlugin.groovy
+++ b/src/main/groovy/wooga/gradle/github/GithubPlugin.groovy
@@ -33,7 +33,7 @@ import wooga.gradle.github.publish.GithubPublishPlugin
  *
  *     github {
  *         username = "wooga"
- *         password = "a password."
+ *         password = "the-password"
  *         token "a github access token"
  *         repositoryName "wooga/atlas-github"
  *         baseUrl = null

--- a/src/main/groovy/wooga/gradle/github/base/Github.groovy
+++ b/src/main/groovy/wooga/gradle/github/base/Github.groovy
@@ -1,8 +1,0 @@
-package wooga.gradle.github.base
-
-class Github extends AbstractGithubTask {
-
-    Github() {
-        super(Github.class)
-    }
-}

--- a/src/main/groovy/wooga/gradle/github/base/GithubBasePlugin.groovy
+++ b/src/main/groovy/wooga/gradle/github/base/GithubBasePlugin.groovy
@@ -21,38 +21,41 @@ import org.gradle.api.Action
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.internal.ConventionMapping
-import org.gradle.api.tasks.TaskContainer
-import wooga.gradle.github.base.internal.DefaultGithubPluginExtention
+import wooga.gradle.github.base.internal.DefaultGithubPluginExtension
 import wooga.gradle.github.base.tasks.internal.AbstractGithubTask
 
+/**
+ * A base {@link org.gradle.api.Plugin} to register and set conventions for all {@link AbstractGithubTask} types.
+ *
+ */
 class GithubBasePlugin implements Plugin<Project> {
 
+    /**
+     * Value for github gradle convention.
+     * @value "github"
+     */
     static final String EXTENSION_NAME = "github"
-    static final String GROUP = "github"
 
-    private Project project
-    private TaskContainer tasks
+    /**
+     * Value for github gradle task group.
+     * @value "github"
+     */
+    static final String GROUP = "github"
 
     @Override
     void apply(Project project) {
-        this.project = project
-        this.tasks = project.tasks
+        def tasks = project.tasks
 
-        GithubPluginExtention extension = project.extensions.create(EXTENSION_NAME, DefaultGithubPluginExtention.class, project.rootProject.properties)
-        configureAbstractGithubTaskDefaults(extension)
-    }
-
-    private void configureAbstractGithubTaskDefaults(GithubPluginExtention extention) {
+        GithubPluginExtention extension = project.extensions.create(EXTENSION_NAME, DefaultGithubPluginExtension.class, project.rootProject.properties)
         tasks.withType(AbstractGithubTask, new Action<AbstractGithubTask>() {
             @Override
             void execute(AbstractGithubTask task) {
                 ConventionMapping taskConventionMapping = task.getConventionMapping()
-
-                taskConventionMapping.map("baseUrl", { extention.getBaseUrl() })
-                taskConventionMapping.map("repositoryName", { extention.getRepositoryName() })
-                taskConventionMapping.map("userName", { extention.getUserName() })
-                taskConventionMapping.map("password", { extention.getPassword() })
-                taskConventionMapping.map("token", { extention.getToken() })
+                taskConventionMapping.map("baseUrl", { extension.getBaseUrl() })
+                taskConventionMapping.map("repositoryName", { extension.getRepositoryName() })
+                taskConventionMapping.map("username", { extension.getUsername() })
+                taskConventionMapping.map("password", { extension.getPassword() })
+                taskConventionMapping.map("token", { extension.getToken() })
             }
         })
     }

--- a/src/main/groovy/wooga/gradle/github/base/GithubBasePlugin.groovy
+++ b/src/main/groovy/wooga/gradle/github/base/GithubBasePlugin.groovy
@@ -20,10 +20,10 @@ package wooga.gradle.github.base
 import org.gradle.api.Action
 import org.gradle.api.Plugin
 import org.gradle.api.Project
-import org.gradle.api.Task
 import org.gradle.api.internal.ConventionMapping
-import org.gradle.api.specs.Spec
 import org.gradle.api.tasks.TaskContainer
+import wooga.gradle.github.base.internal.DefaultGithubPluginExtention
+import wooga.gradle.github.base.tasks.internal.AbstractGithubTask
 
 class GithubBasePlugin implements Plugin<Project> {
 

--- a/src/main/groovy/wooga/gradle/github/base/GithubBasePlugin.groovy
+++ b/src/main/groovy/wooga/gradle/github/base/GithubBasePlugin.groovy
@@ -44,10 +44,8 @@ class GithubBasePlugin implements Plugin<Project> {
 
     @Override
     void apply(Project project) {
-        def tasks = project.tasks
-
         GithubPluginExtention extension = project.extensions.create(EXTENSION_NAME, DefaultGithubPluginExtension.class, project.rootProject.properties)
-        tasks.withType(AbstractGithubTask, new Action<AbstractGithubTask>() {
+        project.tasks.withType(AbstractGithubTask, new Action<AbstractGithubTask>() {
             @Override
             void execute(AbstractGithubTask task) {
                 ConventionMapping taskConventionMapping = task.getConventionMapping()

--- a/src/main/groovy/wooga/gradle/github/base/GithubBasePluginConsts.groovy
+++ b/src/main/groovy/wooga/gradle/github/base/GithubBasePluginConsts.groovy
@@ -1,0 +1,34 @@
+package wooga.gradle.github.base
+
+/**
+ * Constant values for github plugin.
+ */
+class GithubBasePluginConsts {
+    /**
+     * Gradle property name to set the default value for {@code username}.
+     * @value "github.username"
+     * @see GithubSpec#username
+     */
+    static final String GITHUB_USER_NAME_OPTION = "github.username"
+
+    /**
+     * Gradle property name to set the default value for {@code password}.
+     * @value "github.password"
+     * @see GithubSpec#password
+     */
+    static final String GITHUB_USER_PASSWORD_OPTION = "github.password"
+
+    /**
+     * Gradle property name to set the default value for {@code token}.
+     * @value "github.token"
+     * @see GithubSpec#token
+     */
+    static final String GITHUB_TOKEN_OPTION = "github.token"
+
+    /**
+     * Gradle property name to set the default value for {@code repository}.
+     * @value "github.repository"
+     * @see GithubSpec#repositoryName
+     */
+    static final String GITHUB_REPOSITORY_OPTION = "github.repository"
+}

--- a/src/main/groovy/wooga/gradle/github/base/GithubPluginExtention.groovy
+++ b/src/main/groovy/wooga/gradle/github/base/GithubPluginExtention.groovy
@@ -17,6 +17,9 @@
 
 package wooga.gradle.github.base
 
+/**
+ * Extension point for the github plugin.
+ */
 interface GithubPluginExtention extends GithubSpec {
 
 }

--- a/src/main/groovy/wooga/gradle/github/base/GithubSpec.groovy
+++ b/src/main/groovy/wooga/gradle/github/base/GithubSpec.groovy
@@ -17,36 +17,168 @@
 
 package wooga.gradle.github.base
 
-
+/**
+ * Base Task spec definitions for a github tasks/actions.
+ */
 interface GithubSpec {
 
-    String getUserName()
+    /**
+     * Returns the github username.
+     * <p>
+     * The value can also be set via gradle properties.
+     * The precedence order is:
+     * <ul>
+     *    <li><b>direct parameter in code</b>
+     *    <li><b>gradle properties</b>
+     * </ul>
+     * @return the github username. May be {@code Null}
+     * @see    GithubBasePluginConsts#GITHUB_USER_NAME_OPTION
+     */
+    String getUsername()
 
-    GithubSpec setUserName(String userName)
+    /**
+     * Sets the github username.
+     *
+     * @param  username the username. Must not be {@code Null} or {@code empty}
+     * @return this
+     * @throws IllegalArgumentException
+     */
+    GithubSpec setUsername(String username)
 
-    GithubSpec userName(String userName)
+    /**
+     * Sets the github username.
+     *
+     * @param  username the username. Must not be {@code Null} or {@code empty}
+     * @return this
+     * @throws IllegalArgumentException
+     */
+    GithubSpec username(String username)
 
+    /**
+     * Returns the github user password.
+     * <p>
+     * The value can also be set via gradle properties.
+     * The precedence order is:
+     * <ul>
+     *    <li><b>direct parameter in code</b>
+     *    <li><b>gradle properties</b>
+     * </ul>
+     * @return the github username. May be {@code Null}
+     * @see    GithubBasePluginConsts#GITHUB_USER_PASSWORD_OPTION
+     */
     String getPassword()
 
+    /**
+     * Sets the github user password.
+     *
+     * @param  password the password. Must not be {@code Null} or {@code empty}
+     * @return this
+     * @throws IllegalArgumentException
+     */
     GithubSpec setPassword(String password)
 
+    /**
+     * Sets the github user password.
+     *
+     * @param  password the password. Must not be {@code Null} or {@code empty}
+     * @return this
+     * @throws IllegalArgumentException
+     */
     GithubSpec password(String password)
 
+    /**
+     * Returns the github authentication token.
+     * <p>
+     * The value can also be set via gradle properties.
+     * The precedence order is:
+     * <ul>
+     *    <li><b>direct parameter in code</b>
+     *    <li><b>gradle properties</b>
+     * </ul>
+     * @return the github access token. May be {@code Null}
+     * @see    GithubBasePluginConsts#GITHUB_TOKEN_OPTION
+     */
     String getToken()
 
+    /**
+     * Sets the github access token.
+     *
+     * @param  token the token. Must not be {@code Null} or {@code empty}
+     * @return this
+     * @throws IllegalArgumentException
+     */
     GithubSpec setToken(String token)
 
+    /**
+     * Sets the github access token.
+     *
+     * @param  token the token. Must not be {@code Null} or {@code empty}
+     * @return this
+     * @throws IllegalArgumentException
+     */
     GithubSpec token(String token)
 
+    /**
+     * Returns the github repository name.
+     * <p>
+     * The format must be in {@code owner/repositoryname}.
+     *
+     * The value can also be set via gradle properties.
+     * The precedence order is:
+     * <ul>
+     *    <li><b>direct parameter in code</b>
+     *    <li><b>gradle properties</b>
+     * </ul>
+     * @return the github repository name. May be {@code Null}
+     * @see GithubBasePluginConsts#GITHUB_REPOSITORY_OPTION
+     */
     String getRepositoryName()
 
+    /**
+     * Sets the github repository name.
+     * <p>
+     * The given value must be a valid github repository name in the form of {@code owner/repositoryname}.
+     *
+     * @param  name the repository name. Must not be {@code Null} or {@code empty}
+     * @return this
+     * @throws IllegalArgumentException
+     */
     GithubSpec setRepositoryName(String name)
 
+    /**
+     * Sets the github repository name.
+     * <p>
+     * The given value must be a valid github repository name in the form of {@code owner/repositoryname}.
+     *
+     * @param  name the repository name. Must not be {@code Null} or {@code empty}
+     * @return this
+     * @throws IllegalArgumentException
+     */
     GithubSpec repositoryName(String name)
 
+    /**
+     * Returns the github api base url.
+     *
+     * @return the base url
+     * @default https://api.github.com
+     */
     String getBaseUrl()
 
+    /**
+     * Sets the github api base url.
+     *
+     * @param baseUrl the base url for github api. Must not be {@code Null} or {@code empty}
+     * @return this
+     * @throws IllegalArgumentException
+     */
     GithubSpec setBaseUrl(String baseUrl)
 
+    /**
+     * Sets the github api base url.
+     *
+     * @param baseUrl the base url for github api. Must not be {@code Null} or {@code empty}
+     * @return this
+     * @throws IllegalArgumentException
+     */
     GithubSpec baseUrl(String baseUrl)
 }

--- a/src/main/groovy/wooga/gradle/github/base/internal/DefaultGithubPluginExtension.groovy
+++ b/src/main/groovy/wooga/gradle/github/base/internal/DefaultGithubPluginExtension.groovy
@@ -15,9 +15,13 @@
  *
  */
 
-package wooga.gradle.github.base
+package wooga.gradle.github.base.internal
 
-class DefaultGithubPluginExtention implements GithubPluginExtention {
+import wooga.gradle.github.base.GithubPluginExtention
+import wooga.gradle.github.base.GithubSpec
+
+class DefaultGithubPluginExtension implements GithubPluginExtention {
+
     static final String GITHUB_USER_NAME_OPTION = "github.userName"
     static final String GITHUB_USER_PASSWORD_OPTION = "github.password"
     static final String GITHUB_TOKEN_OPTION = "github.token"
@@ -32,7 +36,7 @@ class DefaultGithubPluginExtention implements GithubPluginExtention {
 
     private Map<String, ?> properties
 
-    DefaultGithubPluginExtention(Map<String, ?> properties) {
+    DefaultGithubPluginExtension(Map<String, ?> properties) {
         this.properties = properties
     }
 
@@ -46,13 +50,13 @@ class DefaultGithubPluginExtention implements GithubPluginExtention {
     }
 
     @Override
-    GithubSpec setUserName(String userName) {
+    DefaultGithubPluginExtension setUserName(String userName) {
         if (userName == null || userName.isEmpty()) {
             throw new IllegalArgumentException("userName")
         }
 
         this.userName = userName
-        return this
+        this
     }
 
     @Override
@@ -70,13 +74,13 @@ class DefaultGithubPluginExtention implements GithubPluginExtention {
     }
 
     @Override
-    GithubSpec setPassword(String password) {
+    DefaultGithubPluginExtension setPassword(String password) {
         if (password == null || password.isEmpty()) {
             throw new IllegalArgumentException("password")
         }
 
         this.password = password
-        return this
+        this
     }
 
     @Override
@@ -99,7 +103,7 @@ class DefaultGithubPluginExtention implements GithubPluginExtention {
     }
 
     @Override
-    DefaultGithubPluginExtention setRepositoryName(String name) {
+    DefaultGithubPluginExtension setRepositoryName(String name) {
         if (name == null || name.isEmpty()) {
             throw new IllegalArgumentException("repository")
         }
@@ -109,11 +113,11 @@ class DefaultGithubPluginExtention implements GithubPluginExtention {
         }
 
         this.repositoryName = name
-        return this
+        this
     }
 
     @Override
-    DefaultGithubPluginExtention repositoryName(String name) {
+    DefaultGithubPluginExtension repositoryName(String name) {
         return setRepositoryName(name)
     }
 
@@ -123,17 +127,17 @@ class DefaultGithubPluginExtention implements GithubPluginExtention {
     }
 
     @Override
-    DefaultGithubPluginExtention setBaseUrl(String baseUrl) {
+    DefaultGithubPluginExtension setBaseUrl(String baseUrl) {
         if (baseUrl == null || baseUrl.isEmpty()) {
             throw new IllegalArgumentException("baseUrl")
         }
 
         this.baseUrl = baseUrl
-        return this
+        this
     }
 
     @Override
-    DefaultGithubPluginExtention baseUrl(String baseUrl) {
+    DefaultGithubPluginExtension baseUrl(String baseUrl) {
         return setBaseUrl(baseUrl)
     }
 
@@ -146,16 +150,16 @@ class DefaultGithubPluginExtention implements GithubPluginExtention {
     }
 
     @Override
-    DefaultGithubPluginExtention setToken(String token) {
+    DefaultGithubPluginExtension setToken(String token) {
         if (token == null || token.isEmpty()) {
             throw new IllegalArgumentException("token")
         }
         this.token = token
-        return this
+        this
     }
 
     @Override
-    DefaultGithubPluginExtention token(String token) {
+    DefaultGithubPluginExtension token(String token) {
         return setToken(token)
     }
 }

--- a/src/main/groovy/wooga/gradle/github/base/internal/DefaultGithubPluginExtension.groovy
+++ b/src/main/groovy/wooga/gradle/github/base/internal/DefaultGithubPluginExtension.groovy
@@ -30,7 +30,7 @@ class DefaultGithubPluginExtension implements GithubPluginExtention {
     private String repositoryName
     private String baseUrl
 
-    private String userName
+    private String username
     private String password
     private String token
 
@@ -42,35 +42,27 @@ class DefaultGithubPluginExtension implements GithubPluginExtention {
 
     @Override
     String getUsername() {
-        if (!this.userName && properties[GITHUB_USER_NAME_OPTION]) {
-            return properties[GITHUB_USER_NAME_OPTION]
-        }
-
-        return this.userName
+        this.username ?: properties[GITHUB_USER_NAME_OPTION]
     }
 
     @Override
-    DefaultGithubPluginExtension setUsername(String userName) {
-        if (userName == null || userName.isEmpty()) {
+    DefaultGithubPluginExtension setUsername(String username) {
+        if (username == null || username.isEmpty()) {
             throw new IllegalArgumentException("username")
         }
 
-        this.userName = userName
+        this.username = username
         this
     }
 
     @Override
     GithubSpec username(String username) {
-        return setUsername(username)
+        setUsername(username)
     }
 
     @Override
     String getPassword() {
-        if (!this.password && properties[GITHUB_USER_PASSWORD_OPTION]) {
-            return properties[GITHUB_USER_PASSWORD_OPTION]
-        }
-
-        return this.password
+        this.password ?: properties[GITHUB_USER_PASSWORD_OPTION]
     }
 
     @Override
@@ -85,7 +77,7 @@ class DefaultGithubPluginExtension implements GithubPluginExtention {
 
     @Override
     GithubSpec password(String password) {
-        return setPassword(password)
+        setPassword(password)
     }
 
     @Override
@@ -99,7 +91,7 @@ class DefaultGithubPluginExtension implements GithubPluginExtention {
             throw new IllegalArgumentException("Repository value '$value' is not a valid github repository name. Expecting `owner/repo`.")
         }
 
-        return value
+        value
     }
 
     @Override
@@ -118,12 +110,12 @@ class DefaultGithubPluginExtension implements GithubPluginExtention {
 
     @Override
     DefaultGithubPluginExtension repositoryName(String name) {
-        return setRepositoryName(name)
+        setRepositoryName(name)
     }
 
     @Override
     String getBaseUrl() {
-        return baseUrl
+        baseUrl
     }
 
     @Override
@@ -138,15 +130,12 @@ class DefaultGithubPluginExtension implements GithubPluginExtention {
 
     @Override
     DefaultGithubPluginExtension baseUrl(String baseUrl) {
-        return setBaseUrl(baseUrl)
+        setBaseUrl(baseUrl)
     }
 
     @Override
     String getToken() {
-        if (!this.token && properties[GITHUB_TOKEN_OPTION]) {
-            return properties[GITHUB_TOKEN_OPTION]
-        }
-        return this.token
+        this.token ?: properties[GITHUB_TOKEN_OPTION]
     }
 
     @Override
@@ -160,6 +149,6 @@ class DefaultGithubPluginExtension implements GithubPluginExtention {
 
     @Override
     DefaultGithubPluginExtension token(String token) {
-        return setToken(token)
+        setToken(token)
     }
 }

--- a/src/main/groovy/wooga/gradle/github/base/internal/DefaultGithubPluginExtension.groovy
+++ b/src/main/groovy/wooga/gradle/github/base/internal/DefaultGithubPluginExtension.groovy
@@ -22,7 +22,7 @@ import wooga.gradle.github.base.GithubSpec
 
 class DefaultGithubPluginExtension implements GithubPluginExtention {
 
-    static final String GITHUB_USER_NAME_OPTION = "github.userName"
+    static final String GITHUB_USER_NAME_OPTION = "github.username"
     static final String GITHUB_USER_PASSWORD_OPTION = "github.password"
     static final String GITHUB_TOKEN_OPTION = "github.token"
     static final String GITHUB_REPOSITORY_OPTION = "github.repository"
@@ -41,7 +41,7 @@ class DefaultGithubPluginExtension implements GithubPluginExtention {
     }
 
     @Override
-    String getUserName() {
+    String getUsername() {
         if (!this.userName && properties[GITHUB_USER_NAME_OPTION]) {
             return properties[GITHUB_USER_NAME_OPTION]
         }
@@ -50,9 +50,9 @@ class DefaultGithubPluginExtension implements GithubPluginExtention {
     }
 
     @Override
-    DefaultGithubPluginExtension setUserName(String userName) {
+    DefaultGithubPluginExtension setUsername(String userName) {
         if (userName == null || userName.isEmpty()) {
-            throw new IllegalArgumentException("userName")
+            throw new IllegalArgumentException("username")
         }
 
         this.userName = userName
@@ -60,8 +60,8 @@ class DefaultGithubPluginExtension implements GithubPluginExtention {
     }
 
     @Override
-    GithubSpec userName(String userName) {
-        return setUserName(userName)
+    GithubSpec username(String username) {
+        return setUsername(username)
     }
 
     @Override

--- a/src/main/groovy/wooga/gradle/github/base/internal/GithubRepositoryValidator.groovy
+++ b/src/main/groovy/wooga/gradle/github/base/internal/GithubRepositoryValidator.groovy
@@ -36,6 +36,6 @@ class GithubRepositoryValidator {
             return false
         }
 
-        return true
+        true
     }
 }

--- a/src/main/groovy/wooga/gradle/github/base/internal/GithubRepositoryValidator.groovy
+++ b/src/main/groovy/wooga/gradle/github/base/internal/GithubRepositoryValidator.groovy
@@ -15,7 +15,7 @@
  *
  */
 
-package wooga.gradle.github.base
+package wooga.gradle.github.base.internal
 
 import org.gradle.api.logging.Logger
 import org.gradle.api.logging.Logging

--- a/src/main/groovy/wooga/gradle/github/base/tasks/Github.groovy
+++ b/src/main/groovy/wooga/gradle/github/base/tasks/Github.groovy
@@ -1,0 +1,10 @@
+package wooga.gradle.github.base.tasks
+
+import wooga.gradle.github.base.tasks.internal.AbstractGithubTask
+
+class Github extends AbstractGithubTask {
+
+    Github() {
+        super(Github.class)
+    }
+}

--- a/src/main/groovy/wooga/gradle/github/base/tasks/Github.groovy
+++ b/src/main/groovy/wooga/gradle/github/base/tasks/Github.groovy
@@ -2,6 +2,33 @@ package wooga.gradle.github.base.tasks
 
 import wooga.gradle.github.base.tasks.internal.AbstractGithubTask
 
+/**
+ * Execute arbitrary github API calls.
+ * <p>
+ * This type can be used to build generic tasks who can access the github API through github-api.kohsuke.org.
+ * It implements the {@link wooga.gradle.github.base.GithubSpec} and handles the basic github client creation and
+ * authentication. This type is usable for scripted tasks or can be extended.
+ * Along with the properties from {@link wooga.gradle.github.base.GithubSpec} the task gives access to client and,
+ * if repositoryName is set, to repository property.
+ * <p>
+ * Example:
+ * <pre>
+ * {@code
+ *     task customGithub(type:wooga.gradle.github.base.tasks.Github) {
+ *         doLast {
+ *             def builder = client.createRepository("Repo")
+ *             builder.description("description")
+ *             builder.autoInit(false)
+ *             builder.licenseTemplate('MIT')
+ *             builder.private_(false)
+ *             builder.issues(false)
+ *             builder.wiki(false)
+ *             builder.create()
+ *         }
+ *     }
+ * }
+ * </pre>
+ */
 class Github extends AbstractGithubTask {
 
     Github() {

--- a/src/main/groovy/wooga/gradle/github/base/tasks/internal/AbstractGithubTask.groovy
+++ b/src/main/groovy/wooga/gradle/github/base/tasks/internal/AbstractGithubTask.groovy
@@ -76,7 +76,7 @@ abstract class AbstractGithubTask<T extends AbstractGithubTask> extends Conventi
 
     @Override
     String getRepositoryName() {
-        return repositoryName
+        repositoryName
     }
 
     @Override
@@ -90,19 +90,19 @@ abstract class AbstractGithubTask<T extends AbstractGithubTask> extends Conventi
         }
 
         this.repositoryName = name
-        return taskType.cast(this)
+        taskType.cast(this)
     }
 
     @Override
     T repositoryName(String name) {
-        return taskType.cast(this.setRepositoryName(name))
+        taskType.cast(this.setRepositoryName(name))
     }
 
     @Optional
     @Input
     @Override
     String getBaseUrl() {
-        return baseUrl
+        baseUrl
     }
 
     @Override
@@ -111,19 +111,19 @@ abstract class AbstractGithubTask<T extends AbstractGithubTask> extends Conventi
             throw new IllegalArgumentException("baseUrl")
         }
         this.baseUrl = baseUrl
-        return taskType.cast(this)
+        taskType.cast(this)
     }
 
     @Override
     T baseUrl(String baseUrl) {
-        return taskType.cast(this.setBaseUrl(baseUrl))
+        taskType.cast(this.setBaseUrl(baseUrl))
     }
 
     @Optional
     @Input
     @Override
     String getToken() {
-        return this.token
+        this.token
     }
 
     @Override
@@ -132,49 +132,49 @@ abstract class AbstractGithubTask<T extends AbstractGithubTask> extends Conventi
             throw new IllegalArgumentException("token")
         }
         this.token = token
-        return taskType.cast(this)
+        taskType.cast(this)
     }
 
     @Override
     T token(String token) {
-        return taskType.cast(this.setToken(token))
+        taskType.cast(this.setToken(token))
     }
 
     @Optional
     @Input
     @Override
     String getUsername() {
-        return this.username
+        this.username
     }
 
     @Override
     T setUsername(String userName) {
         this.username = userName
-        return taskType.cast(this)
+        taskType.cast(this)
     }
 
     @Override
     T username(String username) {
         this.setUsername(username)
-        return taskType.cast(this)
+        taskType.cast(this)
     }
 
     @Optional
     @Input
     @Override
     String getPassword() {
-        return this.password
+        this.password
     }
 
     @Override
     T setPassword(String password) {
         this.password = password
-        return taskType.cast(this)
+        taskType.cast(this)
     }
 
     @Override
     T password(String password) {
         this.setPassword(password)
-        return taskType.cast(this)
+        taskType.cast(this)
     }
 }

--- a/src/main/groovy/wooga/gradle/github/base/tasks/internal/AbstractGithubTask.groovy
+++ b/src/main/groovy/wooga/gradle/github/base/tasks/internal/AbstractGithubTask.groovy
@@ -14,7 +14,7 @@ abstract class AbstractGithubTask<T extends AbstractGithubTask> extends Conventi
 
     private String repositoryName
     private String baseUrl
-    private String userName
+    private String username
     private String password
     private String token
 
@@ -30,10 +30,10 @@ abstract class AbstractGithubTask<T extends AbstractGithubTask> extends Conventi
         if(!this.client) {
             def builder = new GitHubBuilder()
 
-            if (getUserName() && getPassword()) {
-                builder = builder.withPassword(getUserName(), getPassword())
-            } else if (getUserName() && getToken()) {
-                builder = builder.withOAuthToken(getToken(), getUserName())
+            if (getUsername() && getPassword()) {
+                builder = builder.withPassword(getUsername(), getPassword())
+            } else if (getUsername() && getToken()) {
+                builder = builder.withOAuthToken(getToken(), getUsername())
 
             } else if (getToken()) {
                 builder = builder.withOAuthToken(getToken())
@@ -143,19 +143,19 @@ abstract class AbstractGithubTask<T extends AbstractGithubTask> extends Conventi
     @Optional
     @Input
     @Override
-    String getUserName() {
-        return this.userName
+    String getUsername() {
+        return this.username
     }
 
     @Override
-    T setUserName(String userName) {
-        this.userName = userName
+    T setUsername(String userName) {
+        this.username = userName
         return taskType.cast(this)
     }
 
     @Override
-    T userName(String userName) {
-        this.setUserName(userName)
+    T username(String username) {
+        this.setUsername(username)
         return taskType.cast(this)
     }
 

--- a/src/main/groovy/wooga/gradle/github/base/tasks/internal/AbstractGithubTask.groovy
+++ b/src/main/groovy/wooga/gradle/github/base/tasks/internal/AbstractGithubTask.groovy
@@ -1,4 +1,4 @@
-package wooga.gradle.github.base
+package wooga.gradle.github.base.tasks.internal
 
 import org.gradle.api.GradleException
 import org.gradle.api.internal.ConventionTask
@@ -7,6 +7,8 @@ import org.gradle.api.tasks.Optional
 import org.kohsuke.github.GHRepository
 import org.kohsuke.github.GitHub
 import org.kohsuke.github.GitHubBuilder
+import wooga.gradle.github.base.internal.GithubRepositoryValidator
+import wooga.gradle.github.base.GithubSpec
 
 abstract class AbstractGithubTask<T extends AbstractGithubTask> extends ConventionTask implements GithubSpec {
 

--- a/src/main/groovy/wooga/gradle/github/publish/GithubPublishPlugin.groovy
+++ b/src/main/groovy/wooga/gradle/github/publish/GithubPublishPlugin.groovy
@@ -39,7 +39,7 @@ import wooga.gradle.github.publish.tasks.GithubPublish
  *
  *     github {
  *         username = "wooga"
- *         password = "a password."
+ *         password = "the_password"
  *         token "a github access token"
  *         repositoryName "wooga/atlas-github"
  *         baseUrl = null
@@ -98,7 +98,7 @@ class GithubPublishPlugin implements Plugin<Project> {
                 task.onlyIf(new Spec<GithubPublish>() {
                     @Override
                     boolean isSatisfiedBy(GithubPublish publishTask) {
-                        return publishTask.repositoryName != null
+                        publishTask.repositoryName != null
                     }
                 })
             }

--- a/src/main/groovy/wooga/gradle/github/publish/GithubPublishPlugin.groovy
+++ b/src/main/groovy/wooga/gradle/github/publish/GithubPublishPlugin.groovy
@@ -27,6 +27,7 @@ import org.gradle.api.specs.Spec
 import org.gradle.api.tasks.TaskContainer
 import wooga.gradle.github.base.GithubBasePlugin
 import wooga.gradle.github.base.GithubPluginExtention
+import wooga.gradle.github.publish.tasks.GithubPublish
 
 class GithubPublishPlugin implements Plugin<Project> {
 

--- a/src/main/groovy/wooga/gradle/github/publish/GithubPublishSpec.groovy
+++ b/src/main/groovy/wooga/gradle/github/publish/GithubPublishSpec.groovy
@@ -46,7 +46,7 @@ import wooga.gradle.github.base.GithubSpec
  *         if (this.releaseName instanceof Callable) {
  *             return ((Callable) this.releaseName).call().toString()
  *         }
- *         return this.releaseName.toString()
+ *         this.releaseName.toString()
  *     }
  * }
  */

--- a/src/main/groovy/wooga/gradle/github/publish/GithubPublishSpec.groovy
+++ b/src/main/groovy/wooga/gradle/github/publish/GithubPublishSpec.groovy
@@ -21,73 +21,323 @@ import org.gradle.api.file.CopySourceSpec
 import org.gradle.api.tasks.util.PatternFilterable
 import wooga.gradle.github.base.GithubSpec
 
+/**
+ * Task spec definition for a github publish task/action.
+ * https://developer.github.com/v3/repos/releases/#create-a-release
+ * <p>
+ * All {@code set} methods come in two flavors.
+ * <ul>
+ *     <li> a set assignment method {@code setTagName(...)}
+ *     <li> a mutator method {@code tagName(...)}
+ *
+ * Both return the current object.
+ * The provided value can be any object with a valid conversion method available ({@code toString}, {@code toBoolean}, etc).
+ * If the value is a {@code Closure} or {@code Callable} and the docs doesn't state otherwise,
+ * the result after calling the object and executing the matching conversion method on the return value will be used.
+ *
+ * All values will be evaluated when calling the {@code get} method.
+ *
+ * <pre>
+ * {@code
+ *     String getReleaseName() {
+ *         if(this.releaseName == null) {
+ *             return null
+ *         }
+ *         if (this.releaseName instanceof Callable) {
+ *             return ((Callable) this.releaseName).call().toString()
+ *         }
+ *         return this.releaseName.toString()
+ *     }
+ * }
+ */
 interface GithubPublishSpec extends GithubSpec, CopySourceSpec, PatternFilterable {
 
+    /**
+     * Returns the name of the Git tag from which to create the release.
+     *
+     * @return the Git tag name
+     */
     String getTagName()
 
-    GithubPublishSpec setTagName(String tagTame)
+    /**
+     * Sets the tag name for the release.
+     *
+     * @param  the {@code String} tagName value
+     * @return this
+     */
+    GithubPublishSpec setTagName(String tagName)
 
-    GithubPublishSpec setTagName(Object tagTame)
+    /**
+     * Sets the tag name for the release.
+     *
+     * @param  the {@code Object} tagName value.
+     * @return this
+     */
+    GithubPublishSpec setTagName(Object tagName)
 
-    GithubPublishSpec tagName(String tagTame)
+    /**
+     * Sets the tag name for the release.
+     *
+     * @param  the {@code String} tagName value
+     * @return this
+     */
+    GithubPublishSpec tagName(String tagName)
 
-    GithubPublishSpec tagName(Object tagTame)
+    /**
+     * Sets the tag name for the release.
+     *
+     * @param  the {@code Object} tagName value.
+     * @return this
+     */
+    GithubPublishSpec tagName(Object tagName)
 
+    /**
+     * Returns the commitish value that determines where the Git tag is created from.
+     * <p>
+     * Can be any branch or commit SHA. Unused if the Git tag already exists.
+     *
+     * @default the repository's default branch (usually master).
+     * @return  this
+     */
     String getTargetCommitish()
 
+    /**
+     * Sets the commitish value.
+     *
+     * @param  targetCommitish the commitish value, can be any branch or commit SHA
+     * @return this
+     */
     GithubPublishSpec setTargetCommitish(String targetCommitish)
 
+    /**
+     * Sets the commitish value.
+     *
+     * @param  targetCommitish the commitish value, can be any branch or commit SHA
+     * @return this
+     */
     GithubPublishSpec setTargetCommitish(Object targetCommitish)
 
+    /**
+     * Sets the commitish value.
+     *
+     * @param  targetCommitish the commitish value, can be any branch or commit SHA
+     * @return this
+     */
     GithubPublishSpec targetCommitish(String targetCommitish)
 
+    /**
+     * Sets the commitish value.
+     *
+     * @param  targetCommitish the commitish value, can be any branch or commit SHA
+     * @return this
+     */
     GithubPublishSpec targetCommitish(Object targetCommitish)
 
+    /**
+     * Returns the name of the release.
+     *
+     * @return the name of the release
+     */
     String getReleaseName()
 
+    /**
+     * Sets the name of the release.
+     *
+     * @param  name the name to use for the release
+     * @return this
+     */
     GithubPublishSpec setReleaseName(String name)
 
+    /**
+     * Sets the name of the release.
+     *
+     * @param  name the name to use for the release
+     * @return this
+     */
     GithubPublishSpec setReleaseName(Object name)
 
+    /**
+     * Sets the name of the release.
+     *
+     * @param  name the name to use for the release
+     * @return this
+     */
     GithubPublishSpec releaseName(String name)
 
+    /**
+     * Sets the name of the release.
+     *
+     * @param  name the name to use for the release
+     * @return this
+     */
     GithubPublishSpec releaseName(Object name)
 
+    /**
+     * Returns the description text of the release
+     *
+     * @return the release description
+     */
     String getBody()
 
+    /**
+     * Sets the description text for the release.
+     *
+     * @param  body the release description
+     * @return this
+     */
     GithubPublishSpec setBody(String body)
 
+    /**
+     * Sets the description text for the release.
+     * <p>
+     * The provided value can be any object with a valid {@code toString} method.
+     * If the value is a {@code Callable}, the result after calling the object
+     * and executing {@code toString} on the return value will be used.
+     *
+     * @param  body the release description
+     * @return this
+     */
     GithubPublishSpec setBody(Object body)
 
+    /**
+     * Sets the description text for the release.
+     * <p>
+     * The closure will be called with a {@link org.kohsuke.github.GHRepository} repository object.
+     * The repository object can be used to query the Git commit log or pull requests etc.
+     *
+     * @param  closure a configuration closure which returns the release description
+     * @return this
+     */
     GithubPublishSpec setBody(Closure closure)
 
+    /**
+     * Sets the description text for the release.
+     * <p>
+     * The body strategies {@code getBody()} method will be called with a {@link org.kohsuke.github.GHRepository} repository object.
+     * The repository object can be used to query the Git commit log or pull requests etc.
+     *
+     * @param  bodyStrategy an object of type {@link PublishBodyStrategy} which returns the release description
+     * @return this
+     * @see    PublishBodyStrategy#getBody(org.kohsuke.github.GHRepository)
+     */
     GithubPublishSpec setBody(PublishBodyStrategy bodyStrategy)
 
+    /**
+     * Sets the description text for the release.
+     *
+     * @param  body the release description
+     * @return this
+     */
     GithubPublishSpec body(String body)
 
+    /**
+     * Sets the description text for the release.
+     *
+     * @param  body the release description
+     * @return this
+     */
     GithubPublishSpec body(Object body)
 
+    /**
+     * Sets the description text for the release.
+     * <p>
+     * The closure will be called with a {@link org.kohsuke.github.GHRepository} repository object.
+     * The repository object can be used to query the Git commit log or pull requests etc.
+     *
+     * @param  closure a configuration closure which returns the release description
+     * @return this
+     */
     GithubPublishSpec body(Closure bodyStrategy)
 
+    /**
+     * Sets the description text for the release.
+     * <p>
+     * The body strategies {@code getBody()} method will be called with a {@link org.kohsuke.github.GHRepository} repository object.
+     * The repository object can be used to query the Git commit log or pull requests etc.
+     *
+     * @param  bodyStrategy an object of type {@link PublishBodyStrategy} which returns the release description
+     * @return this
+     * @see    PublishBodyStrategy#getBody(org.kohsuke.github.GHRepository)
+     */
     GithubPublishSpec body(PublishBodyStrategy bodyStrategy)
 
+    /**
+     * Returns a {@code boolean} value indicating if the release as a prerelease.
+     *
+     * @return  {@code true} to identify the release as a prerelease. {@code false} to identify the release as a full release.
+     * @default {@code false}
+     */
     boolean isPrerelease()
 
+    /**
+     * Sets the prerelease status of the release.
+     *
+     * @param  prerelease the prerelease status. Set {@code true} to identify the release as a prerelease.
+     * @return this
+     */
     GithubPublishSpec setPrerelease(boolean prerelease)
 
+    /**
+     * Sets the prerelease status of the release.
+     *
+     * @param  prerelease the prerelease status. Set {@code true} to identify the release as a prerelease.
+     * @return this
+     */
     GithubPublishSpec setPrerelease(Object prerelease)
 
+    /**
+     * Sets the prerelease status of the release.
+     *
+     * @param  prerelease the prerelease status. Set {@code true} to identify the release as a prerelease.
+     * @return this
+     */
     GithubPublishSpec prerelease(boolean prerelease)
 
+    /**
+     * Sets the prerelease status of the release.
+     *
+     * @param  prerelease the prerelease status. Set {@code true} to identify the release as a prerelease.
+     * @return this
+     */
     GithubPublishSpec prerelease(Object prerelease)
 
+    /**
+     * Returns a {@code boolean} value indicating if the release will be automatically published.
+     *
+     * @return  {@code true} to create a draft (unpublished) release, {@code false} to create a published one.
+     * @default {@code false}
+     */
     boolean isDraft()
 
+    /**
+     * Sets the publication status for the release.
+     *
+     * @param  draft the status. Set to {@code true} to create a draft (unpublished) release.
+     * @return this
+     */
     GithubPublishSpec setDraft(boolean draft)
 
+    /**
+     * Sets the publication status for the release.
+     *
+     * @param  draft the status. Set to {@code true} to create a draft (unpublished) release.
+     * @return this
+     */
     GithubPublishSpec setDraft(Object draft)
 
+    /**
+     * Sets the publication status for the release.
+     *
+     * @param  draft the status. Set to {@code true} to create a draft (unpublished) release.
+     * @return this
+     */
     GithubPublishSpec draft(boolean draft)
 
+    /**
+     * Sets the publication status for the release.
+     *
+     * @param  draft the status. Set to {@code true} to create a draft (unpublished) release.
+     * @return this
+     */
     GithubPublishSpec draft(Object draft)
 }

--- a/src/main/groovy/wooga/gradle/github/publish/PublishBodyStrategy.groovy
+++ b/src/main/groovy/wooga/gradle/github/publish/PublishBodyStrategy.groovy
@@ -19,6 +19,31 @@ package wooga.gradle.github.publish
 
 import org.kohsuke.github.GHRepository
 
+/**
+ * A strategy used to retrieve the github release description.
+ * <p>
+ * Example:
+ * <pre>
+ *     class ReleaseBody implements PublishBodyStrategy {
+ *         @Override
+ *         String getBody(GHRepository repository) {
+ *             repository.listCommits().asList().collect { GHCommit commit ->
+ *                 "[${commit.SHA1}] - ${commit.commitShortInfo.message}"
+ *             }.join("\n")
+ *         }
+ *     }
+ * }
+ * </pre>
+ */
 interface PublishBodyStrategy {
+
+    /**
+     * Returns a release description text.
+     * <p>
+     * The given {@link GHRepository} object can be used to query Git commits etc.
+     *
+     * @param  repository the current github repository object
+     * @return the release description
+     */
     String getBody(GHRepository repository)
 }

--- a/src/main/groovy/wooga/gradle/github/publish/tasks/GithubPublish.groovy
+++ b/src/main/groovy/wooga/gradle/github/publish/tasks/GithubPublish.groovy
@@ -71,7 +71,7 @@ class GithubPublish extends AbstractGithubTask implements GithubPublishSpec {
 
     private File assetCollectDirectory
     private File assetUploadDirectory
-    private CopySpec assetsCopySpec
+    protected CopySpec assetsCopySpec
     private Boolean processAssets
 
     GithubPublish() {
@@ -123,20 +123,20 @@ class GithubPublish extends AbstractGithubTask implements GithubPublishSpec {
         }
     }
 
-    private void failRelease(GHRelease release, String message) {
+    protected void failRelease(GHRelease release, String message) {
         release.delete()
         setDidWork(false)
         throw new GradleException(message)
     }
 
-    private void publishAssets(GHRelease release) {
+    protected void publishAssets(GHRelease release) {
         assetUploadDirectory.eachFile { File assetFile ->
             def contentType = getAssetContentType(assetFile)
             release.uploadAsset(assetFile, contentType)
         }
     }
 
-    private void prepareAssets() {
+    protected void prepareAssets() {
         File uploadDir = this.assetUploadDirectory
         assetCollectDirectory.eachFile(FileType.FILES) {
             FileUtils.copyFileToDirectory(it, uploadDir)
@@ -148,7 +148,7 @@ class GithubPublish extends AbstractGithubTask implements GithubPublishSpec {
         }
     }
 
-    private GHRelease createGithubRelease(Boolean createDraft) {
+    protected GHRelease createGithubRelease(Boolean createDraft) {
         GitHub client = getClient()
         GHRepository repository = getRepository(client)
 
@@ -170,10 +170,10 @@ class GithubPublish extends AbstractGithubTask implements GithubPublishSpec {
             builder.name(getReleaseName())
         }
 
-        return builder.create()
+        builder.create()
     }
 
-    private static String getAssetContentType(File assetFile) {
+    protected static String getAssetContentType(File assetFile) {
         InputStream is = new FileInputStream(assetFile)
         BufferedInputStream bis = new BufferedInputStream(is)
         String contentType = "text/plain"
@@ -189,7 +189,7 @@ class GithubPublish extends AbstractGithubTask implements GithubPublishSpec {
 
         }
 
-        return contentType
+        contentType
     }
 
     /* CopySpec */
@@ -204,7 +204,7 @@ class GithubPublish extends AbstractGithubTask implements GithubPublishSpec {
     GithubPublish from(Object... sourcePaths) {
         assetsCopySpec.from(sourcePaths)
         processAssets = true
-        return this
+        this
     }
 
     /**
@@ -217,7 +217,7 @@ class GithubPublish extends AbstractGithubTask implements GithubPublishSpec {
     @Override
     GithubPublish from(Object sourcePath, Closure configureClosure) {
         this.from(sourcePath, ConfigureUtil.configureUsing(configureClosure))
-        return this
+        this
     }
 
     /**
@@ -231,7 +231,7 @@ class GithubPublish extends AbstractGithubTask implements GithubPublishSpec {
     GithubPublish from(Object sourcePath, Action<? super CopySpec> configureAction) {
         assetsCopySpec.from(sourcePath, configureAction)
         processAssets = true
-        return this
+        this
     }
 
     /**
@@ -241,7 +241,7 @@ class GithubPublish extends AbstractGithubTask implements GithubPublishSpec {
      */
     @Override
     Set<String> getIncludes() {
-        return assetsCopySpec.getIncludes()
+        assetsCopySpec.getIncludes()
     }
 
     /**
@@ -251,7 +251,7 @@ class GithubPublish extends AbstractGithubTask implements GithubPublishSpec {
      */
     @Override
     Set<String> getExcludes() {
-        return assetsCopySpec.getExcludes()
+        assetsCopySpec.getExcludes()
     }
 
     /**
@@ -265,7 +265,7 @@ class GithubPublish extends AbstractGithubTask implements GithubPublishSpec {
     @Override
     GithubPublish setIncludes(Iterable<String> includes) {
         assetsCopySpec.setIncludes(includes)
-        return this
+        this
     }
 
     /**
@@ -279,7 +279,7 @@ class GithubPublish extends AbstractGithubTask implements GithubPublishSpec {
     @Override
     GithubPublish setExcludes(Iterable<String> excludes) {
         assetsCopySpec.setExcludes(excludes)
-        return this
+        this
     }
 
     /**
@@ -296,7 +296,7 @@ class GithubPublish extends AbstractGithubTask implements GithubPublishSpec {
     @Override
     GithubPublish include(String... includes) {
         assetsCopySpec.include(includes)
-        return this
+        this
     }
 
     /**
@@ -312,7 +312,7 @@ class GithubPublish extends AbstractGithubTask implements GithubPublishSpec {
      */
     @Override
     GithubPublish include(Iterable<String> includes) {
-        return this.setIncludes(includes)
+        this.setIncludes(includes)
     }
 
     /**
@@ -328,7 +328,7 @@ class GithubPublish extends AbstractGithubTask implements GithubPublishSpec {
     @Override
     GithubPublish include(Spec<FileTreeElement> includeSpec) {
         assetsCopySpec.include(includeSpec)
-        return this
+        this
     }
 
     /**
@@ -344,7 +344,7 @@ class GithubPublish extends AbstractGithubTask implements GithubPublishSpec {
      */
     @Override
     GithubPublish include(Closure includeSpec) {
-        return this.include(Specs.<FileTreeElement>convertClosureToSpec(includeSpec))
+        this.include(Specs.<FileTreeElement>convertClosureToSpec(includeSpec))
     }
 
     /**
@@ -361,7 +361,7 @@ class GithubPublish extends AbstractGithubTask implements GithubPublishSpec {
     @Override
     GithubPublish exclude(String... excludes) {
         assetsCopySpec.exclude(excludes)
-        return this
+        this
     }
 
     /**
@@ -377,7 +377,7 @@ class GithubPublish extends AbstractGithubTask implements GithubPublishSpec {
      */
     @Override
     GithubPublish exclude(Iterable<String> excludes) {
-        return this.setExcludes(excludes)
+        this.setExcludes(excludes)
     }
 
     /**
@@ -393,7 +393,7 @@ class GithubPublish extends AbstractGithubTask implements GithubPublishSpec {
     @Override
     GithubPublish exclude(Spec<FileTreeElement> excludeSpec) {
         assetsCopySpec.exclude(excludeSpec)
-        return this
+        this
     }
 
     /**
@@ -418,7 +418,7 @@ class GithubPublish extends AbstractGithubTask implements GithubPublishSpec {
      */
     @Override
     GithubPublish exclude(Closure excludeSpec) {
-        return this.exclude(Specs.<FileTreeElement>convertClosureToSpec(excludeSpec))
+        this.exclude(Specs.<FileTreeElement>convertClosureToSpec(excludeSpec))
     }
 
     private Object tagName
@@ -443,7 +443,7 @@ class GithubPublish extends AbstractGithubTask implements GithubPublishSpec {
             return ((Callable) this.tagName).call().toString()
         }
 
-        return this.tagName.toString()
+        this.tagName.toString()
     }
 
     /**
@@ -452,7 +452,7 @@ class GithubPublish extends AbstractGithubTask implements GithubPublishSpec {
     @Override
     GithubPublish setTagName(String tagName) {
         this.tagName = tagName
-        return this
+        this
     }
 
     /**
@@ -461,7 +461,7 @@ class GithubPublish extends AbstractGithubTask implements GithubPublishSpec {
     @Override
     GithubPublish setTagName(Object tagName) {
         this.tagName = tagName
-        return this
+        this
     }
 
     /**
@@ -469,7 +469,7 @@ class GithubPublish extends AbstractGithubTask implements GithubPublishSpec {
      */
     @Override
     GithubPublish tagName(String tagName) {
-        return this.setTagName(tagName)
+        this.setTagName(tagName)
     }
 
     /**
@@ -477,7 +477,7 @@ class GithubPublish extends AbstractGithubTask implements GithubPublishSpec {
      */
     @Override
     GithubPublish tagName(Object tagName) {
-        return this.setTagName(tagName)
+        this.setTagName(tagName)
     }
 
     /**
@@ -494,7 +494,7 @@ class GithubPublish extends AbstractGithubTask implements GithubPublishSpec {
             return ((Callable) this.targetCommitish).call().toString()
         }
 
-        return this.targetCommitish.toString()
+        this.targetCommitish.toString()
     }
 
     /**
@@ -503,7 +503,7 @@ class GithubPublish extends AbstractGithubTask implements GithubPublishSpec {
     @Override
     GithubPublish setTargetCommitish(String targetCommitish) {
         this.targetCommitish = targetCommitish
-        return this
+        this
     }
 
     /**
@@ -512,7 +512,7 @@ class GithubPublish extends AbstractGithubTask implements GithubPublishSpec {
     @Override
     GithubPublish setTargetCommitish(Object targetCommitish) {
         this.targetCommitish = targetCommitish
-        return this
+        this
     }
 
     /**
@@ -520,7 +520,7 @@ class GithubPublish extends AbstractGithubTask implements GithubPublishSpec {
      */
     @Override
     GithubPublish targetCommitish(String targetCommitish) {
-        return this.setTargetCommitish(targetCommitish)
+        this.setTargetCommitish(targetCommitish)
     }
 
     /**
@@ -528,7 +528,7 @@ class GithubPublish extends AbstractGithubTask implements GithubPublishSpec {
      */
     @Override
     GithubPublish targetCommitish(Object targetCommitish) {
-        return this.setTargetCommitish(targetCommitish)
+        this.setTargetCommitish(targetCommitish)
     }
 
     /**
@@ -545,7 +545,7 @@ class GithubPublish extends AbstractGithubTask implements GithubPublishSpec {
             return ((Callable) this.releaseName).call().toString()
         }
 
-        return this.releaseName.toString()
+        this.releaseName.toString()
     }
 
     /**
@@ -554,7 +554,7 @@ class GithubPublish extends AbstractGithubTask implements GithubPublishSpec {
     @Override
     GithubPublish setReleaseName(String name) {
         this.releaseName = name
-        return this
+        this
     }
 
     /**
@@ -563,7 +563,7 @@ class GithubPublish extends AbstractGithubTask implements GithubPublishSpec {
     @Override
     GithubPublish setReleaseName(Object name) {
         this.releaseName = name
-        return this
+        this
     }
 
     /**
@@ -571,7 +571,7 @@ class GithubPublish extends AbstractGithubTask implements GithubPublishSpec {
      */
     @Override
     GithubPublish releaseName(Object name) {
-        return this.setReleaseName(name)
+        this.setReleaseName(name)
     }
 
     /**
@@ -579,7 +579,7 @@ class GithubPublish extends AbstractGithubTask implements GithubPublishSpec {
      */
     @Override
     GithubPublish releaseName(String name) {
-        return this.setReleaseName(name)
+        this.setReleaseName(name)
     }
 
     /**
@@ -605,7 +605,7 @@ class GithubPublish extends AbstractGithubTask implements GithubPublishSpec {
             return ((Callable) this.body).call().toString()
         }
 
-        return this.body.toString()
+        this.body.toString()
     }
 
     /**
@@ -614,7 +614,7 @@ class GithubPublish extends AbstractGithubTask implements GithubPublishSpec {
     @Override
     GithubPublish setBody(String body) {
         this.body = body
-        return this
+        this
     }
 
     /**
@@ -623,7 +623,7 @@ class GithubPublish extends AbstractGithubTask implements GithubPublishSpec {
     @Override
     GithubPublish setBody(Object body) {
         this.body = body
-        return this
+        this
     }
 
     /**
@@ -636,7 +636,7 @@ class GithubPublish extends AbstractGithubTask implements GithubPublishSpec {
         }
 
         this.body = closure
-        return this
+        this
     }
 
     /**
@@ -644,7 +644,7 @@ class GithubPublish extends AbstractGithubTask implements GithubPublishSpec {
      */
     GithubPublish setBody(PublishBodyStrategy bodyStrategy) {
         this.body = bodyStrategy
-        return this
+        this
     }
 
     /**
@@ -652,7 +652,7 @@ class GithubPublish extends AbstractGithubTask implements GithubPublishSpec {
      */
     @Override
     GithubPublish body(String body) {
-        return this.setBody(body)
+        this.setBody(body)
     }
 
     /**
@@ -660,7 +660,7 @@ class GithubPublish extends AbstractGithubTask implements GithubPublishSpec {
      */
     @Override
     GithubPublish body(Object body) {
-        return this.setBody(body)
+        this.setBody(body)
     }
 
     /**
@@ -668,7 +668,7 @@ class GithubPublish extends AbstractGithubTask implements GithubPublishSpec {
      */
     @Override
     GithubPublish body(Closure bodyStrategy) {
-        return this.setBody(bodyStrategy)
+        this.setBody(bodyStrategy)
     }
 
     /**
@@ -676,7 +676,7 @@ class GithubPublish extends AbstractGithubTask implements GithubPublishSpec {
      */
     @Override
     GithubPublish body(PublishBodyStrategy bodyStrategy) {
-        return this.setBody(bodyStrategy)
+        this.setBody(bodyStrategy)
     }
 
     /**
@@ -689,7 +689,7 @@ class GithubPublish extends AbstractGithubTask implements GithubPublishSpec {
             return ((Callable) this.prerelease).call().asBoolean()
         }
 
-        return this.prerelease.asBoolean()
+        this.prerelease.asBoolean()
     }
 
     /**
@@ -698,7 +698,7 @@ class GithubPublish extends AbstractGithubTask implements GithubPublishSpec {
     @Override
     GithubPublish setPrerelease(boolean prerelease) {
         this.prerelease = prerelease
-        return this
+        this
     }
 
     /**
@@ -707,7 +707,7 @@ class GithubPublish extends AbstractGithubTask implements GithubPublishSpec {
     @Override
     GithubPublish setPrerelease(Object prerelease) {
         this.prerelease = prerelease
-        return this
+        this
     }
 
     /**
@@ -715,7 +715,7 @@ class GithubPublish extends AbstractGithubTask implements GithubPublishSpec {
      */
     @Override
     GithubPublish prerelease(boolean prerelease) {
-        return this.setPrerelease(prerelease)
+        this.setPrerelease(prerelease)
     }
 
     /**
@@ -723,7 +723,7 @@ class GithubPublish extends AbstractGithubTask implements GithubPublishSpec {
      */
     @Override
     GithubPublish prerelease(Object prerelease) {
-        return this.setPrerelease(prerelease)
+        this.setPrerelease(prerelease)
     }
 
     /**
@@ -736,7 +736,7 @@ class GithubPublish extends AbstractGithubTask implements GithubPublishSpec {
             return ((Callable) this.draft).call().asBoolean()
         }
 
-        return this.draft.asBoolean()
+        this.draft.asBoolean()
     }
 
     /**
@@ -745,7 +745,7 @@ class GithubPublish extends AbstractGithubTask implements GithubPublishSpec {
     @Override
     GithubPublish setDraft(boolean draft) {
         this.draft = draft
-        return this
+        this
     }
 
     /**
@@ -754,7 +754,7 @@ class GithubPublish extends AbstractGithubTask implements GithubPublishSpec {
     @Override
     GithubPublish setDraft(Object draft) {
         this.draft = draft
-        return this
+        this
     }
 
     /**
@@ -762,7 +762,7 @@ class GithubPublish extends AbstractGithubTask implements GithubPublishSpec {
      */
     @Override
     GithubPublish draft(boolean draft) {
-        return this.setDraft(draft)
+        this.setDraft(draft)
     }
 
     /**
@@ -770,6 +770,6 @@ class GithubPublish extends AbstractGithubTask implements GithubPublishSpec {
      */
     @Override
     GithubPublish draft(Object draft) {
-        return this.setDraft(draft)
+        this.setDraft(draft)
     }
 }

--- a/src/main/groovy/wooga/gradle/github/publish/tasks/GithubPublish.groovy
+++ b/src/main/groovy/wooga/gradle/github/publish/tasks/GithubPublish.groovy
@@ -15,7 +15,7 @@
  *
  */
 
-package wooga.gradle.github.publish
+package wooga.gradle.github.publish.tasks
 
 import groovy.io.FileType
 import org.apache.commons.io.FileUtils
@@ -38,7 +38,9 @@ import org.gradle.api.tasks.WorkResult
 import org.gradle.util.ConfigureUtil
 import org.kohsuke.github.*
 import org.zeroturnaround.zip.ZipUtil
-import wooga.gradle.github.base.AbstractGithubTask
+import wooga.gradle.github.base.tasks.internal.AbstractGithubTask
+import wooga.gradle.github.publish.GithubPublishSpec
+import wooga.gradle.github.publish.PublishBodyStrategy
 
 import java.util.concurrent.Callable
 

--- a/src/test/groovy/wooga/gradle/github/GithubPluginActivationSpec.groovy
+++ b/src/test/groovy/wooga/gradle/github/GithubPluginActivationSpec.groovy
@@ -21,5 +21,5 @@ import nebula.test.PluginProjectSpec
 
 class GithubPluginActivationSpec extends PluginProjectSpec {
     @Override
-    String getPluginName() { return 'net.wooga.github' }
+    String getPluginName() { 'net.wooga.github' }
 }

--- a/src/test/groovy/wooga/gradle/github/GithubPluginSpec.groovy
+++ b/src/test/groovy/wooga/gradle/github/GithubPluginSpec.groovy
@@ -22,7 +22,7 @@ import org.gradle.api.publish.plugins.PublishingPlugin
 import spock.lang.Unroll
 import wooga.gradle.github.base.GithubBasePlugin
 import wooga.gradle.github.base.GithubPluginExtention
-import wooga.gradle.github.publish.GithubPublish
+import wooga.gradle.github.publish.tasks.GithubPublish
 import wooga.gradle.github.publish.GithubPublishPlugin
 
 class GithubPluginSpec extends ProjectSpec {

--- a/src/test/groovy/wooga/gradle/github/base/internal/DefaultGithubPluginExtensionSpec.groovy
+++ b/src/test/groovy/wooga/gradle/github/base/internal/DefaultGithubPluginExtensionSpec.groovy
@@ -15,35 +15,37 @@
  *
  */
 
-package wooga.gradle.github.base
+package wooga.gradle.github.base.internal
 
 import spock.lang.Specification
+import spock.lang.Subject
 import spock.lang.Unroll
 
-class DefaultGithubPluginExtentionSpec extends Specification {
+@Subject(DefaultGithubPluginExtension)
+class DefaultGithubPluginExtensionSpec extends Specification {
 
     Map<String, String> properties = [:]
 
-    def extension = new DefaultGithubPluginExtention(properties)
+    def extension = new DefaultGithubPluginExtension(properties)
 
     @Unroll
     def "retrieve default values from properties when set #userNameValue:#passwordValue:#tokenValue:#repositoryValue"() {
         given: "project properties with values"
 
         if (userNameValue) {
-            properties[DefaultGithubPluginExtention.GITHUB_USER_NAME_OPTION] = userNameValue
+            properties[DefaultGithubPluginExtension.GITHUB_USER_NAME_OPTION] = userNameValue
         }
 
         if (passwordValue) {
-            properties[DefaultGithubPluginExtention.GITHUB_USER_PASSWORD_OPTION] = passwordValue
+            properties[DefaultGithubPluginExtension.GITHUB_USER_PASSWORD_OPTION] = passwordValue
         }
 
         if (tokenValue) {
-            properties[DefaultGithubPluginExtention.GITHUB_TOKEN_OPTION] = tokenValue
+            properties[DefaultGithubPluginExtension.GITHUB_TOKEN_OPTION] = tokenValue
         }
 
         if (repositoryValue) {
-            properties[DefaultGithubPluginExtention.GITHUB_REPOSITORY_OPTION] = repositoryValue
+            properties[DefaultGithubPluginExtension.GITHUB_REPOSITORY_OPTION] = repositoryValue
         }
 
         expect:
@@ -83,8 +85,8 @@ class DefaultGithubPluginExtentionSpec extends Specification {
 
         where:
         valueToTest      | propertyKey                                           | propertyValue
-        "repositoryName" | DefaultGithubPluginExtention.GITHUB_REPOSITORY_OPTION | "invalid-repo-name"
-        "repositoryName" | DefaultGithubPluginExtention.GITHUB_REPOSITORY_OPTION | "https://github.com/some/repo"
+        "repositoryName" | DefaultGithubPluginExtension.GITHUB_REPOSITORY_OPTION | "invalid-repo-name"
+        "repositoryName" | DefaultGithubPluginExtension.GITHUB_REPOSITORY_OPTION | "https://github.com/some/repo"
     }
 
     @Unroll("#methodName throws IllegalArgumentException when value is #propertyMessage")

--- a/src/test/groovy/wooga/gradle/github/base/internal/DefaultGithubPluginExtensionSpec.groovy
+++ b/src/test/groovy/wooga/gradle/github/base/internal/DefaultGithubPluginExtensionSpec.groovy
@@ -50,8 +50,8 @@ class DefaultGithubPluginExtensionSpec extends Specification {
 
         expect:
         with(extension) {
-            userName == userNameValue
-            getUserName() == userNameValue
+            username == userNameValue
+            getUsername() == userNameValue
 
             password == passwordValue
             getPassword() == passwordValue
@@ -165,14 +165,14 @@ class DefaultGithubPluginExtensionSpec extends Specification {
     def "userName setter throws IllegalArgumentException"() {
         when:
         if (useSetter) {
-            extension.setUserName(propertyValue)
+            extension.setUsername(propertyValue)
         } else {
-            extension.userName(propertyValue)
+            extension.username(propertyValue)
         }
 
         then:
         IllegalArgumentException e = thrown()
-        e.message == "userName"
+        e.message == "username"
 
         where:
         propertyValue | useSetter
@@ -182,7 +182,7 @@ class DefaultGithubPluginExtensionSpec extends Specification {
         ""            | false
 
         propertyMessage = propertyValue == null ? propertyValue : "empty"
-        methodName = useSetter ? "setUserName" : "userName"
+        methodName = useSetter ? "setUsername" : "username"
     }
 
     @Unroll("#methodName throws IllegalArgumentException when value is #propertyMessage")
@@ -239,7 +239,7 @@ class DefaultGithubPluginExtensionSpec extends Specification {
         if (useSetter) {
             with(extension) {
                 setBaseUrl("baseURL")
-                setUserName("userName")
+                setUsername("username")
                 setPassword("password")
                 setToken("token")
                 setRepositoryName("test/repository")
@@ -248,7 +248,7 @@ class DefaultGithubPluginExtensionSpec extends Specification {
         } else {
             with(extension) {
                 baseUrl("baseURL")
-                userName("userName")
+                username("username")
                 password("password")
                 token("token")
                 repositoryName("test/repository")
@@ -258,7 +258,7 @@ class DefaultGithubPluginExtensionSpec extends Specification {
         then:
         with(extension) {
             baseUrl == "baseURL"
-            userName == "userName"
+            username == "username"
             password == "password"
             token == "token"
             repositoryName == "test/repository"

--- a/src/test/groovy/wooga/gradle/github/base/internal/GithubRepositoryValidatorSpec.groovy
+++ b/src/test/groovy/wooga/gradle/github/base/internal/GithubRepositoryValidatorSpec.groovy
@@ -15,11 +15,14 @@
  *
  */
 
-package wooga.gradle.github.base
+package wooga.gradle.github.base.internal
 
 import spock.lang.Specification
+import spock.lang.Subject
 import spock.lang.Unroll
+import wooga.gradle.github.base.internal.GithubRepositoryValidator
 
+@Subject(GithubRepositoryValidator)
 class GithubRepositoryValidatorSpec extends Specification {
 
     @Unroll


### PR DESCRIPTION
## Description
This pull requests adds API docs for all public interfaces and classes. Along with the documentations are slight restructures and some name changes to move this plugin more in line with the other gradle plugins.

## Changes
* ![ADD] groovy doc strings
* ![IMPROVE] restrucure plugin sources

[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:http://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:http://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:http://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://resources.atlas.wooga.com/icons/icon_webGL.svg "Web:GL"
