### PR TITLE
Issue #17 and #18

### DIFF
--- a/src/main/groovy/wooga/gradle/github/publish/tasks/GithubPublish.groovy
+++ b/src/main/groovy/wooga/gradle/github/publish/tasks/GithubPublish.groovy
@@ -93,7 +93,7 @@ class GithubPublish extends AbstractGithubTask implements GithubPublishSpec {
     @TaskAction
     protected void publish() {
         setDidWork(false)
-        GHRelease release = createGithubRelease(this.processAssets)
+        GHRelease release = createGithubRelease(this.processAssets || isDraft())
 
         if (this.processAssets) {
             WorkResult assetCopyResult = project.copy(new Action<CopySpec>()

--- a/src/main/groovy/wooga/gradle/github/publish/tasks/GithubPublish.groovy
+++ b/src/main/groovy/wooga/gradle/github/publish/tasks/GithubPublish.groovy
@@ -109,7 +109,9 @@ class GithubPublish extends AbstractGithubTask implements GithubPublishSpec {
                 try {
                     prepareAssets()
                     publishAssets(release)
-                    release.update().draft(isDraft()).tag(getTagName()).update()
+                    if (release.draft != isDraft()) {
+                        release.update().draft(isDraft()).tag(getTagName()).update()
+                    }
                 }
                 catch (Exception e) {
                     failRelease(release, "error while uploading assets. Rollback release ${release.name}")

--- a/src/main/groovy/wooga/gradle/github/publish/tasks/GithubPublish.groovy
+++ b/src/main/groovy/wooga/gradle/github/publish/tasks/GithubPublish.groovy
@@ -109,7 +109,7 @@ class GithubPublish extends AbstractGithubTask implements GithubPublishSpec {
                 try {
                     prepareAssets()
                     publishAssets(release)
-                    release.update().draft(isDraft()).update()
+                    release.update().draft(isDraft()).tag(getTagName()).update()
                 }
                 catch (Exception e) {
                     failRelease(release, "error while uploading assets. Rollback release ${release.name}")


### PR DESCRIPTION
- Work around GitHub bug or quirk that sometimes resets tag names when trying to set a release to draft state (#18)
- Do not make an unnecessary API call if the draft state is already correct (#18)
- Do not ignore the draft property when creating a release without assets (#17)