### PR TITLE
Fix temporary file handling in GithubPublish

### DIFF
--- a/src/main/groovy/wooga/gradle/github/publish/tasks/GithubPublish.groovy
+++ b/src/main/groovy/wooga/gradle/github/publish/tasks/GithubPublish.groovy
@@ -77,10 +77,9 @@ class GithubPublish extends AbstractGithubTask implements GithubPublishSpec {
     GithubPublish() {
         super(GithubPublish.class)
         assetsCopySpec = project.copySpec()
-        assetCollectDirectory = File.createTempDir("github-publish-collect", name)
-        assetUploadDirectory = File.createTempDir("github-publish-prepare", name)
-        assetCollectDirectory.deleteOnExit()
-        assetUploadDirectory.deleteOnExit()
+
+        assetCollectDirectory = project.file("${temporaryDir}/collect")
+        assetUploadDirectory = project.file("${temporaryDir}/prepare")
     }
 
     File getDestinationDir() {
@@ -96,7 +95,7 @@ class GithubPublish extends AbstractGithubTask implements GithubPublishSpec {
         GHRelease release = createGithubRelease(this.processAssets || isDraft())
 
         if (this.processAssets) {
-            WorkResult assetCopyResult = project.copy(new Action<CopySpec>()
+            WorkResult assetCopyResult = project.sync(new Action<CopySpec>()
             {
                 @Override
                 void execute(CopySpec copySpec) {
@@ -140,6 +139,9 @@ class GithubPublish extends AbstractGithubTask implements GithubPublishSpec {
 
     protected void prepareAssets() {
         File uploadDir = this.assetUploadDirectory
+        uploadDir.deleteDir()
+        uploadDir.mkdirs()
+
         assetCollectDirectory.eachFile(FileType.FILES) {
             FileUtils.copyFileToDirectory(it, uploadDir)
         }


### PR DESCRIPTION
## Description

Applying the suggestion from #12 and use the gradle task temp directory instead of using the `File` API. This keeps the files after a gradle run in the build directory to check for bugs or issues.

resolves #12

## Changes

![IMPROVE] temporary file handling

[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:http://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:http://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:http://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://resources.atlas.wooga.com/icons/icon_webGL.svg "Web:GL"
