### PR TITLE
Consider calculated project properties

### DIFF
--- a/src/main/groovy/wooga/gradle/github/base/GithubBasePlugin.groovy
+++ b/src/main/groovy/wooga/gradle/github/base/GithubBasePlugin.groovy
@@ -44,7 +44,7 @@ class GithubBasePlugin implements Plugin<Project> {
 
     @Override
     void apply(Project project) {
-        GithubPluginExtention extension = project.extensions.create(EXTENSION_NAME, DefaultGithubPluginExtension.class, project.rootProject.properties)
+        GithubPluginExtention extension = project.extensions.create(EXTENSION_NAME, DefaultGithubPluginExtension.class, project)
         project.tasks.withType(AbstractGithubTask, new Action<AbstractGithubTask>() {
             @Override
             void execute(AbstractGithubTask task) {

--- a/src/main/groovy/wooga/gradle/github/base/internal/DefaultGithubPluginExtension.groovy
+++ b/src/main/groovy/wooga/gradle/github/base/internal/DefaultGithubPluginExtension.groovy
@@ -17,6 +17,7 @@
 
 package wooga.gradle.github.base.internal
 
+import org.gradle.api.Project
 import wooga.gradle.github.base.GithubPluginExtention
 import wooga.gradle.github.base.GithubSpec
 
@@ -34,15 +35,19 @@ class DefaultGithubPluginExtension implements GithubPluginExtention {
     private String password
     private String token
 
-    private Map<String, ?> properties
+    private final Closure property
+
+    DefaultGithubPluginExtension(Project project) {
+        this.property = project.&findProperty
+    }
 
     DefaultGithubPluginExtension(Map<String, ?> properties) {
-        this.properties = properties
+        this.property = properties.&get
     }
 
     @Override
     String getUsername() {
-        this.username ?: properties[GITHUB_USER_NAME_OPTION]
+        this.username ?: property(GITHUB_USER_NAME_OPTION)
     }
 
     @Override
@@ -62,7 +67,7 @@ class DefaultGithubPluginExtension implements GithubPluginExtention {
 
     @Override
     String getPassword() {
-        this.password ?: properties[GITHUB_USER_PASSWORD_OPTION]
+        this.password ?: property(GITHUB_USER_PASSWORD_OPTION)
     }
 
     @Override
@@ -83,8 +88,8 @@ class DefaultGithubPluginExtension implements GithubPluginExtention {
     @Override
     String getRepositoryName() {
         String value = this.repositoryName
-        if (!this.repositoryName && properties[GITHUB_REPOSITORY_OPTION]) {
-            value = properties[GITHUB_REPOSITORY_OPTION]
+        if (!this.repositoryName && property(GITHUB_REPOSITORY_OPTION)) {
+            value = property(GITHUB_REPOSITORY_OPTION)
         }
 
         if (value && !GithubRepositoryValidator.validateRepositoryName(value)) {
@@ -135,7 +140,7 @@ class DefaultGithubPluginExtension implements GithubPluginExtention {
 
     @Override
     String getToken() {
-        this.token ?: properties[GITHUB_TOKEN_OPTION]
+        this.token ?: property(GITHUB_TOKEN_OPTION)
     }
 
     @Override


### PR DESCRIPTION
## Description
Having the following in a project with the project-specific token set did not work as the plugin took a snapshot of the properties
of the root project when the extension was created instead of accessing the properties live when needed.

```gradle
ext {
    it.'github.token' = project.findProperty('my-project.github.token') ?: project.findProperty('github.token')
}
```

With this change it works fine either way.

## Changes

![IMPROVE] lazy property resolution in `DefaultGithubPluginExtension`

[IMPROVE]:http://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"