### PR TITLE
Fix release asset upload with special characters in filename

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,4 +44,7 @@ dependencies {
     compile 'org.kohsuke:github-api:1.94'
     compile 'org.zeroturnaround:zt-zip:1.8'
     compile 'org.apache.tika:tika-core:1.3'
+    testCompile('com.nagternal:spock-genesis:0.6.0') {
+        exclude group: "org.codehaus.groovy", module: "groovy-all"
+    }
 }

--- a/src/main/groovy/wooga/gradle/github/publish/tasks/GithubPublish.groovy
+++ b/src/main/groovy/wooga/gradle/github/publish/tasks/GithubPublish.groovy
@@ -133,7 +133,10 @@ class GithubPublish extends AbstractGithubTask implements GithubPublishSpec {
     protected void publishAssets(GHRelease release) {
         assetUploadDirectory.eachFile { File assetFile ->
             def contentType = getAssetContentType(assetFile)
-            release.uploadAsset(assetFile, contentType)
+            FileInputStream s = new FileInputStream(assetFile)
+            String fileName = URLEncoder.encode(assetFile.name, "UTF-8")
+
+            release.uploadAsset(fileName, s, contentType)
         }
     }
 


### PR DESCRIPTION
## Description

The API `GHAsset uploadAsset(File file, String contentType)` in `GHRelease` is does no `URLEncode` for the given file name. The filename is used in the github API call as is:

```java
String url = format("https://uploads.github.com%s/releases/%d/assets?name=%s",
                 owner.getApiTailUrl(""), getId(), filename);
```

This leads to upload errors when trying to publish files with special characters. This patch circumvents this issue by calling the second API `GHAsset uploadAsset(String filename, InputStream stream, String contentType)` with a URL encoded filename.

### Note

Github renames release assets with special characters.

## Changes

![FIX] release asset upload with special characters in filename


[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:http://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:http://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:http://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://resources.atlas.wooga.com/icons/icon_webGL.svg "Web:GL"
