### PR TITLE
Improve release asset upload with retry handling

### DIFF
--- a/src/integrationTest/groovy/wooga/gradle/github/GithubAuthenticationIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/github/GithubAuthenticationIntegrationSpec.groovy
@@ -29,7 +29,6 @@ class GithubAuthenticationIntegrationSpec extends GithubPublishIntegration {
             github.repositoryName = "$testRepositoryName"
 
             task testPublish(type:wooga.gradle.github.publish.tasks.GithubPublish) {
-                from "releaseAssets"
                 tagName = "v0.${Math.abs(new Random().nextInt() % 1000) + 1}.0-GithubAuthenticationIntegrationSpec"
             }
         """.stripIndent()

--- a/src/main/groovy/wooga/gradle/github/publish/internal/ReleaseAssetUpload.groovy
+++ b/src/main/groovy/wooga/gradle/github/publish/internal/ReleaseAssetUpload.groovy
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2019 Wooga GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package wooga.gradle.github.publish.internal
+
+import org.apache.tika.detect.Detector
+import org.apache.tika.metadata.Metadata
+import org.apache.tika.mime.MediaType
+import org.apache.tika.parser.AutoDetectParser
+import org.kohsuke.github.GHAsset
+import org.kohsuke.github.GHRelease
+import org.kohsuke.github.HttpException
+
+class ReleaseAssetUpload {
+    static GHAsset uploadAsset(GHRelease release, File assetFile) {
+        def contentType = getAssetContentType(assetFile)
+        FileInputStream stream = new FileInputStream(assetFile)
+        String fileName = URLEncoder.encode(assetFile.name, "UTF-8")
+
+        uploadAsset(release, fileName, stream, contentType)
+    }
+
+    static GHAsset uploadAsset(GHRelease release, String fileName, InputStream stream, String contentType) {
+        uploadAssetRetry(release, fileName, stream, contentType)
+    }
+
+    private static GHAsset uploadAssetRetry(GHRelease release, String fileName, InputStream stream, String contentType, int retryCount = 0) {
+        try {
+            release.uploadAsset(fileName, stream, contentType)
+        } catch(HttpException error) {
+            if (error.responseCode == 502 && retryCount < maxRetries) {
+                return uploadAssetRetry(release, fileName, stream, contentType, ++retryCount)
+            }
+
+            throw error
+        }
+    }
+
+    private static int getMaxRetries() {
+        Integer.parseInt(System.getProperty("net.wooga.github.publish.assetUpload.retries", "3"))
+    }
+
+    private static String getAssetContentType(File assetFile) {
+        InputStream is = new FileInputStream(assetFile)
+        BufferedInputStream bis = new BufferedInputStream(is)
+        String contentType = "text/plain"
+        try {
+            AutoDetectParser parser = new AutoDetectParser()
+            Detector detector = parser.getDetector()
+            Metadata md = new Metadata()
+            md.add(Metadata.RESOURCE_NAME_KEY, assetFile.name)
+            MediaType mediaType = detector.detect(bis, md)
+            contentType = mediaType.toString()
+        }
+        finally {
+
+        }
+
+        contentType
+    }
+
+}

--- a/src/main/groovy/wooga/gradle/github/publish/tasks/GithubPublish.groovy
+++ b/src/main/groovy/wooga/gradle/github/publish/tasks/GithubPublish.groovy
@@ -41,6 +41,7 @@ import org.zeroturnaround.zip.ZipUtil
 import wooga.gradle.github.base.tasks.internal.AbstractGithubTask
 import wooga.gradle.github.publish.GithubPublishSpec
 import wooga.gradle.github.publish.PublishBodyStrategy
+import wooga.gradle.github.publish.internal.ReleaseAssetUpload
 
 import java.util.concurrent.Callable
 
@@ -132,11 +133,7 @@ class GithubPublish extends AbstractGithubTask implements GithubPublishSpec {
 
     protected void publishAssets(GHRelease release) {
         assetUploadDirectory.eachFile { File assetFile ->
-            def contentType = getAssetContentType(assetFile)
-            FileInputStream s = new FileInputStream(assetFile)
-            String fileName = URLEncoder.encode(assetFile.name, "UTF-8")
-
-            release.uploadAsset(fileName, s, contentType)
+            ReleaseAssetUpload.uploadAsset(release, assetFile)
         }
     }
 
@@ -178,25 +175,6 @@ class GithubPublish extends AbstractGithubTask implements GithubPublishSpec {
         }
 
         builder.create()
-    }
-
-    protected static String getAssetContentType(File assetFile) {
-        InputStream is = new FileInputStream(assetFile)
-        BufferedInputStream bis = new BufferedInputStream(is)
-        String contentType = "text/plain"
-        try {
-            AutoDetectParser parser = new AutoDetectParser()
-            Detector detector = parser.getDetector()
-            Metadata md = new Metadata()
-            md.add(Metadata.RESOURCE_NAME_KEY, assetFile.name)
-            MediaType mediaType = detector.detect(bis, md)
-            contentType = mediaType.toString()
-        }
-        finally {
-
-        }
-
-        contentType
     }
 
     /* CopySpec */

--- a/src/test/groovy/wooga/gradle/github/publish/internal/ReleaseAssetUploadSpec.groovy
+++ b/src/test/groovy/wooga/gradle/github/publish/internal/ReleaseAssetUploadSpec.groovy
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2019 Wooga GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package wooga.gradle.github.publish.internal
+
+
+import org.kohsuke.github.GHAsset
+import org.kohsuke.github.GHRelease
+import org.kohsuke.github.HttpException
+import spock.lang.Shared
+import spock.lang.Specification
+import spock.util.environment.RestoreSystemProperties
+
+@RestoreSystemProperties
+class ReleaseAssetUploadSpec extends Specification {
+
+    @Shared
+    GHRelease release
+
+    @Shared
+    GHAsset publishedAsset
+
+    def setup() {
+        release = Mock(GHRelease)
+        publishedAsset = Mock(GHAsset)
+        System.clearProperty("net.wooga.github.publish.assetUpload.retries")
+    }
+
+    def "retries up to default value of 3"() {
+        given: "a mock asset to publish"
+        def asset = File.createTempFile("ReleaseAssetUploadSpec","publishAsset")
+        asset << """some text content"""
+
+        and: "a retry counter"
+        def counter = 0
+
+        and: "a mocked exception"
+        release.uploadAsset(_,_,_) >> { ++counter; throw new HttpException("", 502, "", "") }
+
+        when:
+        ReleaseAssetUpload.uploadAsset(release, asset)
+
+        then:
+        thrown(HttpException)
+        counter == 4
+    }
+
+    def "retries up to value defined in system properties"() {
+        given: "a mock asset to publish"
+        def asset = File.createTempFile("ReleaseAssetUploadSpec","publishAsset")
+        asset << """some text content"""
+
+        and: "a retry count defined in system properties"
+        def maxRetries = 20
+        System.setProperty('net.wooga.github.publish.assetUpload.retries', maxRetries.toString())
+
+        and: "a retry counter"
+        def counter = 0
+
+        and: "a mocked exception"
+        release.uploadAsset(_,_,_) >> { ++counter; throw new HttpException("", 502, "", "") }
+
+        when:
+        ReleaseAssetUpload.uploadAsset(release, asset)
+
+        then:
+        thrown(HttpException)
+        counter == maxRetries + 1
+    }
+
+    def "returns asset after success"() {
+        given: "a mock asset to publish"
+        def asset = File.createTempFile("ReleaseAssetUploadSpec","publishAsset")
+        asset << """some text content"""
+
+        and: "a retry counter"
+        def counter = 0
+
+        and: "a mocked exception"
+        release.uploadAsset(_,_,_) >> { ++counter; throw new HttpException("", 502, "", "") } >> publishedAsset
+
+        when:
+        def result = ReleaseAssetUpload.uploadAsset(release, asset)
+
+        then:
+        noExceptionThrown()
+        result == publishedAsset
+        counter == 1
+    }
+}


### PR DESCRIPTION
## Description

Github sometimes returns `502 (Bad Gateway)` during asset upload. This patch adds a retry handler which tries to reupload the failed asset.

## Changes

![IMPROVE] release asset upload with retry handling


[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:http://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:http://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:http://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://resources.atlas.wooga.com/icons/icon_webGL.svg "Web:GL"
