### PR TITLE
Add update release feature

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,6 +44,9 @@ dependencies {
     compile 'org.kohsuke:github-api:1.94'
     compile 'org.zeroturnaround:zt-zip:1.8'
     compile 'org.apache.tika:tika-core:1.3'
+    testCompile('org.spockframework:spock-core:1.2-groovy-2.4') {
+        exclude module: 'groovy-all'
+    }
     testCompile('com.nagternal:spock-genesis:0.6.0') {
         exclude group: "org.codehaus.groovy", module: "groovy-all"
     }

--- a/src/integrationTest/groovy/wooga/gradle/github/GithubPublishIntegration.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/github/GithubPublishIntegration.groovy
@@ -24,8 +24,8 @@ import org.kohsuke.github.PagedIterable
 import spock.lang.Retry
 import spock.lang.Shared
 
-@Retry(count = 3)
-class GithubPublishIntegration extends IntegrationSpec {
+@Retry(mode=Retry.Mode.SETUP_FEATURE_CLEANUP)
+abstract class GithubPublishIntegration extends IntegrationSpec {
     String uniquePostfix() {
         String key = "TRAVIS_JOB_NUMBER"
         def env = System.getenv()

--- a/src/integrationTest/groovy/wooga/gradle/github/GithubPublishIntegration.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/github/GithubPublishIntegration.groovy
@@ -21,8 +21,10 @@ import org.kohsuke.github.GHRelease
 import org.kohsuke.github.GHRepository
 import org.kohsuke.github.GitHub
 import org.kohsuke.github.PagedIterable
+import spock.lang.Retry
 import spock.lang.Shared
 
+@Retry(count = 3)
 class GithubPublishIntegration extends IntegrationSpec {
     String uniquePostfix() {
         String key = "TRAVIS_JOB_NUMBER"

--- a/src/integrationTest/groovy/wooga/gradle/github/GithubPublishIntegrationWithDefaultAuth.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/github/GithubPublishIntegrationWithDefaultAuth.groovy
@@ -17,6 +17,9 @@
 
 package wooga.gradle.github
 
+import spock.lang.Retry
+
+@Retry(count = 3)
 abstract class GithubPublishIntegrationWithDefaultAuth extends GithubPublishIntegration {
 
     def setup() {

--- a/src/integrationTest/groovy/wooga/gradle/github/GithubPublishIntegrationWithDefaultAuth.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/github/GithubPublishIntegrationWithDefaultAuth.groovy
@@ -19,7 +19,7 @@ package wooga.gradle.github
 
 import spock.lang.Retry
 
-@Retry(count = 3)
+@Retry(mode=Retry.Mode.SETUP_FEATURE_CLEANUP)
 abstract class GithubPublishIntegrationWithDefaultAuth extends GithubPublishIntegration {
 
     def setup() {

--- a/src/integrationTest/groovy/wooga/gradle/github/GithubPublishPropertySpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/github/GithubPublishPropertySpec.groovy
@@ -18,9 +18,12 @@
 package wooga.gradle.github
 
 import org.kohsuke.github.GHRepository
+import spock.lang.Retry
 import spock.lang.Unroll
 import wooga.gradle.github.publish.PublishBodyStrategy
+import wooga.gradle.github.publish.PublishMethod
 
+@Retry(mode=Retry.Mode.SETUP_FEATURE_CLEANUP)
 class GithubPublishPropertySpec extends GithubPublishIntegration {
 
     def "task skips if repository is not set"() {
@@ -421,7 +424,6 @@ class GithubPublishPropertySpec extends GithubPublishIntegration {
             }            
         """.stripIndent()
 
-        then:
         when:
         runTasksSuccessfully("testPublish")
 
@@ -436,6 +438,59 @@ class GithubPublishPropertySpec extends GithubPublishIntegration {
         "testReleaseTagFour"  | false     | true
 
         methodName = useSetter ? "setTagName" : "tagName"
+        methodValue = isLazy ? "closure" : "value"
+        preValue = isLazy ? "{" : ""
+        postValue = isLazy ? "}" : ""
+        tagName = "v0.3.${Math.abs(new Random().nextInt() % 1000) + 1}-GithubPublishPropertySpec"
+        versionName = tagName.replaceFirst('v', '')
+    }
+
+    @Unroll
+    def "can set publishMethod with #publishMethod #methodValue and #methodName"() {
+        given: "files to publish"
+        createTestAssetsToPublish(1)
+
+        and: "optional release"
+        if(publishMethod == PublishMethod.update) {
+            createRelease(tagName)
+        }
+
+        and: "a buildfile with publish task"
+        buildFile << """
+            version "$versionName"
+
+            task testPublish(type:wooga.gradle.github.publish.tasks.GithubPublish) {
+                from "releaseAssets"
+                $methodName($preValue "$publishMethod" $postValue)
+                draft = false
+                tagName = "${tagName}"
+                repositoryName = "$testRepositoryName"
+                token = "$testUserToken"
+            }
+        """.stripIndent()
+
+        when:
+        runTasksSuccessfully("testPublish")
+
+        then:
+        hasRelease(tagName)
+
+        where:
+        publishMethod                | useSetter | isLazy
+        PublishMethod.create         | true      | false
+        PublishMethod.create         | true      | true
+        PublishMethod.create         | false     | false
+        PublishMethod.create         | false     | true
+        PublishMethod.update         | true      | false
+        PublishMethod.update         | true      | true
+        PublishMethod.update         | false     | false
+        PublishMethod.update         | false     | true
+        PublishMethod.createOrUpdate | true      | false
+        PublishMethod.createOrUpdate | true      | true
+        PublishMethod.createOrUpdate | false     | false
+        PublishMethod.createOrUpdate | false     | true
+
+        methodName = useSetter ? "setPublishMethod" : "publishMethod"
         methodValue = isLazy ? "closure" : "value"
         preValue = isLazy ? "{" : ""
         postValue = isLazy ? "}" : ""
@@ -541,7 +596,7 @@ class GithubPublishPropertySpec extends GithubPublishIntegration {
 
         methodName = useSetter ? "setBaseUrl" : "baseUrl"
     }
-    
+
     def "fails when release can't be created with generic exception"() {
         given: "files to publish"
         createTestAssetsToPublish(1)

--- a/src/integrationTest/groovy/wooga/gradle/github/GithubPublishPropertySpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/github/GithubPublishPropertySpec.groovy
@@ -559,6 +559,6 @@ class GithubPublishPropertySpec extends GithubPublishIntegration {
 
         expect:
         def result = runTasksWithFailure("testPublish")
-        outputContains(result, "error while uploading assets. Rollback release")
+        outputContains(result, "publish github release failed")
     }
 }

--- a/src/main/groovy/wooga/gradle/github/publish/GithubPublishSpec.groovy
+++ b/src/main/groovy/wooga/gradle/github/publish/GithubPublishSpec.groovy
@@ -340,4 +340,65 @@ interface GithubPublishSpec extends GithubSpec, CopySourceSpec, PatternFilterabl
      * @return this
      */
     GithubPublishSpec draft(Object draft)
+
+    /**
+     * Returns a {@code PublishMethod} value indicating if a release should be created or updated.
+     *
+     * Potential values are
+     * * create
+     * * update
+     * * createOrUpdate
+     *
+     * This method parameter can be used to specify the intention of the publish operation. The {@code GithubPublish}
+     * will use the given @{code tagName} to find a release in the repository.
+     * When set to {@code create}, the {@code GithubPublish} task will fail if a release already exists.
+     * When set to {@code update}, the {@code GithubPublish} task will fail if a release doesn't exists.
+     * When set to {@code createOrUpdate}, the {@code GithubPublish} task will create a release if missing.
+     *
+     * @return  {@code PublishMethod} indicating if a release should be created or updated.
+     * @default {@code PublishMethod.create}
+     * @see wooga.gradle.github.publish.tasks.GithubPublish
+     * @see wooga.gradle.github.publish.PublishMethod
+     */
+    PublishMethod getPublishMethod()
+
+    /**
+     * Sets the publish method.
+     *
+     * @param  {@code PublishMethod} indicating if a release should be created or updated.
+     * @return this
+     *
+     * @see #getPublishMethod()
+     */
+    GithubPublishSpec setPublishMethod(PublishMethod method)
+
+    /**
+     * Sets the publish method.
+     *
+     * @param  {@code Object} which can be converted to a {@code PublishMethod}
+     * @return this
+     *
+     * @see #getPublishMethod()
+     */
+    GithubPublishSpec setPublishMethod(Object method)
+
+    /**
+     * Sets the publish method.
+     *
+     * @param  {@code PublishMethod} indicating if a release should be created or updated.
+     * @return this
+     *
+     * @see #getPublishMethod()
+     */
+    GithubPublishSpec publishMethod(PublishMethod method)
+
+    /**
+     * Sets the publish method.
+     *
+     * @param  {@code Object} which can be converted to a {@code PublishMethod}
+     * @return this
+     *
+     * @see #getPublishMethod()
+     */
+    GithubPublishSpec publishMethod(Object method)
 }

--- a/src/main/groovy/wooga/gradle/github/publish/PublishMethod.groovy
+++ b/src/main/groovy/wooga/gradle/github/publish/PublishMethod.groovy
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2019 Wooga GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package wooga.gradle.github.publish
+
+enum PublishMethod {
+    create,
+    update,
+    createOrUpdate
+}

--- a/src/main/groovy/wooga/gradle/github/publish/internal/GithubPublishRollbackHandler.groovy
+++ b/src/main/groovy/wooga/gradle/github/publish/internal/GithubPublishRollbackHandler.groovy
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2019 Wooga GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package wooga.gradle.github.publish.internal
+
+
+import org.gradle.api.logging.Logger
+import org.gradle.api.logging.Logging
+import org.kohsuke.github.GHRelease
+
+class GithubPublishRollbackHandler {
+    private static final Logger logger = Logging.getLogger(GithubPublishRollbackHandler)
+
+    static void rollback(GHRelease release, boolean deleteRelease, Throwable cause = null) {
+        logger.error("publish github release failed")
+        logger.error("attempt rollback")
+        if (deleteRelease && release) {
+            logger.info("delete created release")
+            try {
+                release.delete()
+            } catch (Exception error) {
+                logger.error("failed to rollback release")
+                logger.error(error.message)
+            }
+        }
+
+        if(release && cause && cause.cause && GithubReleaseUploadAssetException.isInstance(cause.cause) && !deleteRelease) {
+            GithubReleaseUploadAssetException rootCause = cause.cause as GithubReleaseUploadAssetException
+            rootCause.uploadedAssets.each {
+                try {
+                    logger.info("delete published asset ${it.name}")
+                    it.delete()
+                } catch (Exception error) {
+                    logger.error("failed to rollback asset ${it.name}")
+                    logger.error(error.message)
+                }
+            }
+
+            rootCause.updatedAssets.each {
+                try {
+                    logger.info("restore updated asset ${it.name}")
+                    it.restore(release)
+                } catch (Exception error) {
+                    logger.error("failed to restore asset ${it.name}")
+                    logger.error(error.message)
+                }
+            }
+        }
+    }
+}

--- a/src/main/groovy/wooga/gradle/github/publish/internal/GithubReleasePropertySetter.groovy
+++ b/src/main/groovy/wooga/gradle/github/publish/internal/GithubReleasePropertySetter.groovy
@@ -1,0 +1,147 @@
+/*
+ * Copyright 2019 Wooga GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package wooga.gradle.github.publish.internal
+
+
+import org.kohsuke.github.GHRelease
+import org.kohsuke.github.GHReleaseBuilder
+import org.kohsuke.github.GHReleaseUpdater
+
+/**
+ * A utility wrapper type.
+ *
+ * This object is a wrapper around either {@code GHReleaseBuilder} or {@code GHReleaseUpdater} objects.
+ * It allows to pass objects of these types to be handled with a common interface.
+ */
+class GithubReleasePropertySetter {
+
+    private final GHReleaseUpdater updater
+    private final GHReleaseBuilder builder
+
+    GithubReleasePropertySetter(GHReleaseUpdater updater) {
+        this.updater = updater
+        this.builder = null
+    }
+
+    GithubReleasePropertySetter(GHReleaseBuilder builder) {
+        this.builder = builder
+        this.updater = null
+    }
+
+    /**
+     * @param body The release notes body.
+     */
+    GithubReleasePropertySetter body(String body) {
+        if(updater) {
+            updater.body(body)
+        }
+
+        if(builder) {
+            builder.body(body)
+        }
+
+        this
+    }
+
+    /**
+     * Specifies the commitish value that determines where the Git tag is created from. Can be any branch or
+     * commit SHA.
+     *
+     * @param commitish Defaults to the repository’s default branch (usually "master"). Unused if the Git tag
+     *                  already exists.
+     */
+    GithubReleasePropertySetter commitish(String commitish) {
+        if(updater) {
+            updater.commitish(commitish)
+        }
+
+        if(builder) {
+            builder.commitish(commitish)
+        }
+
+        this
+    }
+
+    /**
+     * Optional.
+     *
+     * @param draft {@code true} to create a draft (unpublished) release, {@code false} to create a published one.
+     *                          Default is {@code false}.
+     */
+    GithubReleasePropertySetter draft(boolean draft) {
+        if(updater) {
+            updater.draft(draft)
+        }
+
+        if(builder) {
+            builder.draft(draft)
+        }
+        this
+    }
+
+    /**
+     * @param name the name of the release
+     */
+    GithubReleasePropertySetter name(String name) {
+        if(updater) {
+            updater.name(name)
+        }
+
+        if(builder) {
+            builder.name(name)
+        }
+        this
+    }
+
+    /**
+     * Optional
+     *
+     * @param prerelease {@code true} to identify the release as a prerelease. {@code false} to identify the release
+     *                               as a full release. Default is {@code false}.
+     */
+    GithubReleasePropertySetter prerelease(boolean prerelease) {
+        if(updater) {
+            updater.prerelease(prerelease)
+        }
+
+        if(builder) {
+            builder.prerelease(prerelease)
+        }
+        this
+    }
+
+    /**
+     * Executes the builders native commit method.
+     *
+     * If the wrapped object is a {@code GHReleaseUpdater}, calls {@code update}.
+     * If the wrapped object is a {@code GHReleaseBuilder}, calls {@code create}.
+     *
+     * @return the created or updated {@code GHRelease} object
+     * @throws IOException
+     */
+    GHRelease commit() throws IOException {
+        if(updater) {
+            return updater.update()
+        }
+
+        if(builder) {
+            return builder.create()
+        }
+        return null
+    }
+}

--- a/src/main/groovy/wooga/gradle/github/publish/internal/GithubReleasePublishException.groovy
+++ b/src/main/groovy/wooga/gradle/github/publish/internal/GithubReleasePublishException.groovy
@@ -58,15 +58,6 @@ class GithubReleaseUpdateException extends GithubReleasePublishException {
 
 @InheritConstructors
 class GithubReleaseUploadAssetsException extends GithubReleasePublishException {
-
-    GithubReleaseUploadAssetsException(GHRelease release, String message) {
-        super(release, message)
-
-    }
-
-    GithubReleaseUploadAssetsException(GHRelease release, String message, Throwable cause) {
-        super(release, message, cause)
-    }
 }
 
 @InheritConstructors

--- a/src/main/groovy/wooga/gradle/github/publish/internal/GithubReleasePublishException.groovy
+++ b/src/main/groovy/wooga/gradle/github/publish/internal/GithubReleasePublishException.groovy
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2019 Wooga GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package wooga.gradle.github.publish.internal
+
+import groovy.transform.InheritConstructors
+import org.kohsuke.github.GHAsset
+import org.kohsuke.github.GHRelease
+import wooga.gradle.github.publish.tasks.GithubPublish
+
+class GithubReleasePublishException extends Exception {
+    final private GHRelease release
+
+    GithubReleasePublishException(String message) {
+        this(null, message, null)
+    }
+
+    GithubReleasePublishException(String message, Throwable cause) {
+        this(null, message, cause)
+
+    }
+
+    GithubReleasePublishException(GHRelease release, String message) {
+        this(release, message, null)
+    }
+
+    GithubReleasePublishException(GHRelease release, String message, Throwable cause) {
+        super(message, cause)
+        this.release = release
+    }
+
+    GHRelease getRelease() {
+        this.release
+    }
+}
+
+@InheritConstructors
+class GithubReleaseCreateException extends GithubReleasePublishException {
+}
+
+@InheritConstructors
+class GithubReleaseUpdateException extends GithubReleasePublishException {
+}
+
+@InheritConstructors
+class GithubReleaseUploadAssetsException extends GithubReleasePublishException {
+
+    GithubReleaseUploadAssetsException(GHRelease release, String message) {
+        super(release, message)
+
+    }
+
+    GithubReleaseUploadAssetsException(GHRelease release, String message, Throwable cause) {
+        super(release, message, cause)
+    }
+}
+
+@InheritConstructors
+class GithubReleaseUploadAssetException extends GithubReleasePublishException {
+
+    List<GHAsset> uploadedAssets
+    List<GithubPublish.UpdatedAsset> updatedAssets
+
+    GithubReleaseUploadAssetException(List<GHAsset> uploadedAssets, List<GithubPublish.UpdatedAsset> updatedAssets, Throwable cause) {
+        super("failed to restore asset", cause)
+
+        this.uploadedAssets = uploadedAssets
+        this.updatedAssets = updatedAssets
+    }
+
+}

--- a/src/main/groovy/wooga/gradle/github/publish/tasks/GithubPublish.groovy
+++ b/src/main/groovy/wooga/gradle/github/publish/tasks/GithubPublish.groovy
@@ -109,6 +109,7 @@ class GithubPublish extends AbstractGithubTask implements GithubPublishSpec {
     }
 
     protected void processReleaseAssets(GHRelease release) throws GithubReleaseUploadAssetsException, GithubReleaseUpdateException{
+        getDestinationDir().mkdirs()
         WorkResult assetCopyResult = project.sync(new Action<CopySpec>()
         {
             @Override

--- a/src/main/groovy/wooga/gradle/github/publish/tasks/GithubPublish.groovy
+++ b/src/main/groovy/wooga/gradle/github/publish/tasks/GithubPublish.groovy
@@ -18,11 +18,8 @@
 package wooga.gradle.github.publish.tasks
 
 import groovy.io.FileType
+import groovy.json.JsonSlurper
 import org.apache.commons.io.FileUtils
-import org.apache.tika.detect.Detector
-import org.apache.tika.metadata.Metadata
-import org.apache.tika.mime.MediaType
-import org.apache.tika.parser.AutoDetectParser
 import org.gradle.api.Action
 import org.gradle.api.GradleException
 import org.gradle.api.file.CopySpec
@@ -41,6 +38,13 @@ import org.zeroturnaround.zip.ZipUtil
 import wooga.gradle.github.base.tasks.internal.AbstractGithubTask
 import wooga.gradle.github.publish.GithubPublishSpec
 import wooga.gradle.github.publish.PublishBodyStrategy
+import wooga.gradle.github.publish.PublishMethod
+import wooga.gradle.github.publish.internal.GithubReleasePropertySetter
+import wooga.gradle.github.publish.internal.GithubReleaseCreateException
+import wooga.gradle.github.publish.internal.GithubReleasePublishException
+import wooga.gradle.github.publish.internal.GithubReleaseUpdateException
+import wooga.gradle.github.publish.internal.GithubReleaseUploadAssetException
+import wooga.gradle.github.publish.internal.GithubReleaseUploadAssetsException
 import wooga.gradle.github.publish.internal.ReleaseAssetUpload
 
 import java.util.concurrent.Callable
@@ -49,7 +53,7 @@ import java.util.concurrent.Callable
  * Publish a Github release with or without provided assets.
  * <p>
  * The task implements {@link org.gradle.api.file.CopySourceSpec} and {@link org.gradle.api.tasks.util.PatternFilterable}.
- * Assets to upload can be specified via copy spec syntax.
+ * Assets to restore can be specified via copy spec syntax.
  * <p>
  * Example:
  * <pre>
@@ -61,10 +65,10 @@ import java.util.concurrent.Callable
  *         body = "Release XYZ"
  *         prerelease = false
  *         draft = false
- *
+ *         publishMethod = "create"
  *         from(file('build/output'))
  *     }
- * }
+ *}
  */
 class GithubPublish extends AbstractGithubTask implements GithubPublishSpec {
 
@@ -74,6 +78,7 @@ class GithubPublish extends AbstractGithubTask implements GithubPublishSpec {
     private File assetUploadDirectory
     protected CopySpec assetsCopySpec
     private Boolean processAssets
+    private Boolean isNewlyCreatedRelease = false
 
     GithubPublish() {
         super(GithubPublish.class)
@@ -88,53 +93,170 @@ class GithubPublish extends AbstractGithubTask implements GithubPublishSpec {
     }
 
     /**
-     * executes the plublish process
+     * executes the publish process
      */
     @TaskAction
     protected void publish() {
-        setDidWork(false)
-        GHRelease release = createGithubRelease(this.processAssets || isDraft())
+        try {
+            GHRelease release = createOrUpdateGithubRelease(this.processAssets || isDraft())
+            if (this.processAssets) {
+                processReleaseAssets(release)
+            }
+        } catch (GithubReleasePublishException releaseError) {
+            failRelease(releaseError.getRelease(), releaseError.message, isNewlyCreatedRelease, releaseError)
+        }
+        setDidWork(true)
+    }
 
-        if (this.processAssets) {
-            WorkResult assetCopyResult = project.sync(new Action<CopySpec>()
-            {
-                @Override
-                void execute(CopySpec copySpec) {
-                    copySpec.into(getDestinationDir())
-                    copySpec.with(assetsCopySpec)
-                }
-            })
+    protected void processReleaseAssets(GHRelease release) throws GithubReleaseUploadAssetsException, GithubReleaseUpdateException{
+        WorkResult assetCopyResult = project.sync(new Action<CopySpec>()
+        {
+            @Override
+            void execute(CopySpec copySpec) {
+                copySpec.into(getDestinationDir())
+                copySpec.with(assetsCopySpec)
+            }
+        })
 
-            if (assetCopyResult.didWork) {
-                try {
-                    prepareAssets()
-                    publishAssets(release)
-                    if (release.draft != isDraft()) {
-                        release.update().draft(isDraft()).tag(getTagName()).update()
-                    }
+        if (assetCopyResult.didWork) {
+            try {
+                prepareAssets()
+                publishAssets(release)
+            }
+            catch (Exception error) {
+                throw new GithubReleaseUploadAssetsException(release, "error while uploading assets.", error)
+            }
+
+            try {
+                if (release.draft != isDraft()) {
+                    release.update().draft(isDraft()).tag(getTagName()).update()
                 }
-                catch (Exception e) {
-                    failRelease(release, "error while uploading assets. Rollback release ${release.name}")
-                }
-                setDidWork(true)
-            } else {
-                failRelease(release, "error while preparing assets for upload. Rollback release ${release.name}")
+            } catch (Exception error) {
+                throw new GithubReleaseUpdateException(release, "error while publishing draft", error)
             }
         } else {
-            setDidWork(true)
+            throw new GithubReleaseUploadAssetsException(release, "error while preparing assets for restore")
         }
     }
 
-    protected void failRelease(GHRelease release, String message) {
-        release.delete()
+    protected void failRelease(GHRelease release, String message, boolean deleteRelease, Throwable cause = null) {
         setDidWork(false)
-        throw new GradleException(message)
+        logger.error("publish github release failed")
+        logger.error("attempt rollback")
+        if (deleteRelease && release) {
+            logger.info("delete created release")
+            try {
+                release.delete()
+            } catch (Exception error) {
+                logger.error("failed to rollback release")
+                logger.error(error.message)
+            }
+        }
+
+        if(cause && cause.cause && GithubReleaseUploadAssetException.isInstance(cause.cause) && !deleteRelease) {
+            GithubReleaseUploadAssetException rootCause = cause.cause as GithubReleaseUploadAssetException
+            rootCause.uploadedAssets.each {
+                try {
+                    logger.info("delete published asset ${it.name}")
+                    it.delete()
+                } catch (Exception error) {
+                    logger.error("failed to rollback asset ${it.name}")
+                    logger.error(error.message)
+                }
+            }
+
+            rootCause.updatedAssets.each {
+                try {
+                    logger.info("restore updated asset ${it.name}")
+                    it.restore(release)
+                } catch (Exception error) {
+                    logger.error("failed to restore asset ${it.name}")
+                    logger.error(error.message)
+                }
+            }
+        }
+
+        setDidWork(false)
+        throw new GradleException(message, cause)
     }
 
-    protected void publishAssets(GHRelease release) {
-        assetUploadDirectory.eachFile { File assetFile ->
-            ReleaseAssetUpload.uploadAsset(release, assetFile)
+    static class UpdatedAsset {
+        private String name
+        private String contentType
+        private File file
+
+
+        UpdatedAsset(String name, String contentType, File file) {
+            this.name = name
+            this.contentType = contentType
+            this.file = file
         }
+
+        static UpdatedAsset fromAsset(GHAsset asset) {
+            File tempFile = File.createTempFile(asset.name, "update_asset")
+            def assetURL = new URL(asset.browserDownloadUrl)
+            assetURL.withInputStream { i ->
+                tempFile.withOutputStream {
+                    it << i
+                }
+            }
+
+            new UpdatedAsset(asset.name, asset.contentType, tempFile)
+        }
+
+        GHAsset restore(GHRelease release) {
+            ReleaseAssetUpload.uploadAssetRetry(release, name, new FileInputStream(file), contentType)
+        }
+    }
+
+    protected void publishAssets(GHRelease release) throws GithubReleaseUploadAssetException {
+        List<GHAsset> publishedAssets = []
+        List<UpdatedAsset> updatedAssets = []
+
+        assetUploadDirectory.listFiles().findAll {it.isFile()}.sort().each { File assetFile ->
+            try {
+                publishedAssets << ReleaseAssetUpload.uploadAsset(release, assetFile)
+            } catch (HttpException httpError) {
+                if( isDuplicateAssetError(httpError)) {
+                    logger.info("asset ${assetFile.name} already published")
+                    logger.info("attempt override")
+                    def duplicateAsset = release.assets.find {it.name == assetFile.name}
+                    if(duplicateAsset) {
+                        try {
+                            UpdatedAsset updatedAsset = UpdatedAsset.fromAsset(duplicateAsset)
+                            duplicateAsset.delete()
+                            updatedAssets << updatedAsset
+                            publishedAssets << ReleaseAssetUpload.uploadAsset(release, assetFile)
+                        } catch(Exception e) {
+                            logger.error("failure during update of duplicate asset ${assetFile.name}")
+                            logger.error(e.message)
+                            logger.info("fail with original error")
+                            throw new GithubReleaseUploadAssetException(publishedAssets, updatedAssets, e)
+                        }
+                    } else {
+                        logger.error("unable to find duplicate asset ${assetFile.name} in release assets")
+                        logger.error("this could mean the asset contains special characters!")
+                        throw new GithubReleaseUploadAssetException(publishedAssets, updatedAssets, httpError)
+                    }
+                } else {
+                    throw new GithubReleaseUploadAssetException(publishedAssets, updatedAssets, httpError)
+                }
+            }
+        }
+    }
+
+    protected static Boolean isDuplicateAssetError(HttpException httpError) {
+        Boolean status = false
+        if (httpError.responseCode == 422) {
+            def json = new JsonSlurper()
+            Map details = json.parse(httpError.getMessage().chars) as Map
+            List<Map> errors = details["errors"] as List<Map>
+            if (errors && errors.first() && errors.first()["code"] == "already_exists") {
+                status = true
+            }
+        }
+
+        return status
     }
 
     protected void prepareAssets() {
@@ -152,29 +274,60 @@ class GithubPublish extends AbstractGithubTask implements GithubPublishSpec {
         }
     }
 
-    protected GHRelease createGithubRelease(Boolean createDraft) {
+    protected GHRelease createOrUpdateGithubRelease(Boolean createDraft) throws GithubReleaseUpdateException, GithubReleaseCreateException {
         GitHub client = getClient()
         GHRepository repository = getRepository(client)
 
-        PagedIterable<GHRelease> releases = repository.listReleases()
-        if (releases.find { it.tagName == getTagName() }) {
-            throw new GradleException("github release with tag ${getTagName()} already exist")
+        GHRelease release = repository.listReleases().find({ it.tagName == getTagName() }) as GHRelease
+        GithubReleasePropertySetter releasePropertySet
+        GHRelease result
+        if (release) {
+            if (this.getPublishMethod() == PublishMethod.create) {
+                throw new GithubReleaseCreateException("github release with tag ${getTagName()} already exist")
+            }
+
+            releasePropertySet = new GithubReleasePropertySetter(release.update())
+            releasePropertySet.draft(isDraft())
+
+            try {
+                result = setReleasePropertiesAndCommit(releasePropertySet)
+            } catch (Exception error) {
+                throw new GithubReleaseUpdateException("failed to update release ${release.tagName}", error)
+            }
+        } else {
+            if (this.getPublishMethod() == PublishMethod.update) {
+                throw new GithubReleaseUpdateException("github release with tag ${getTagName()} for update not found")
+            }
+
+            isNewlyCreatedRelease = true
+            releasePropertySet = new GithubReleasePropertySetter(repository.createRelease(getTagName()))
+            releasePropertySet.draft(createDraft as boolean)
+
+            try {
+                result = setReleasePropertiesAndCommit(releasePropertySet)
+            } catch (Exception error) {
+                throw new GithubReleaseCreateException("failed to create release ${release.tagName}", error)
+            }
+        }
+        result
+    }
+
+    protected GHRelease setReleasePropertiesAndCommit(GithubReleasePropertySetter releasePropertySet) {
+        releasePropertySet.prerelease(isPrerelease())
+
+        if (getTargetCommitish()) {
+            releasePropertySet.commitish(getTargetCommitish())
         }
 
-        GHReleaseBuilder builder = repository.createRelease(getTagName())
-        builder.draft(createDraft as boolean)
-        builder.prerelease(isPrerelease())
-        builder.commitish(getTargetCommitish())
-
         if (getBody()) {
-            builder.body(getBody())
+            releasePropertySet.body(getBody())
         }
 
         if (getReleaseName()) {
-            builder.name(getReleaseName())
+            releasePropertySet.name(getReleaseName())
         }
 
-        builder.create()
+        releasePropertySet.commit()
     }
 
     /* CopySpec */
@@ -194,7 +347,7 @@ class GithubPublish extends AbstractGithubTask implements GithubPublishSpec {
 
     /**
      * Specifies the source files or directories for a copy and creates a child {@code CopySourceSpec}. The given source
-     * path is evaluated as per {@link org.gradle.api.Project#files(Object...)} .
+     * path is evaluated as per {@link org.gradle.api.Project#files(Object ...)} .
      *
      * @param sourcePath Path to source for the copy
      * @param configureClosure closure for configuring the child CopySourceSpec
@@ -207,7 +360,7 @@ class GithubPublish extends AbstractGithubTask implements GithubPublishSpec {
 
     /**
      * Specifies the source files or directories for a copy and creates a child {@code CopySpec}. The given source
-     * path is evaluated as per {@link org.gradle.api.Project#files(Object...)} .
+     * path is evaluated as per {@link org.gradle.api.Project#files(Object ...)} .
      *
      * @param sourcePath Path to source for the copy
      * @param configureAction action for configuring the child CopySpec
@@ -244,8 +397,7 @@ class GithubPublish extends AbstractGithubTask implements GithubPublishSpec {
      * defined includes.
      *
      * @param includes an Iterable providing new include patterns
-     * @return this
-     * @see org.gradle.api.tasks.util.PatternFilterable Pattern Format
+     * @return this* @see org.gradle.api.tasks.util.PatternFilterable Pattern Format
      */
     @Override
     GithubPublish setIncludes(Iterable<String> includes) {
@@ -258,8 +410,7 @@ class GithubPublish extends AbstractGithubTask implements GithubPublishSpec {
      * defined excludes.
      *
      * @param excludes an Iterable providing new exclude patterns
-     * @return this
-     * @see org.gradle.api.tasks.util.PatternFilterable Pattern Format
+     * @return this* @see org.gradle.api.tasks.util.PatternFilterable Pattern Format
      */
     @Override
     GithubPublish setExcludes(Iterable<String> excludes) {
@@ -275,8 +426,7 @@ class GithubPublish extends AbstractGithubTask implements GithubPublishSpec {
      * file must match at least one of the include patterns to be processed.
      *
      * @param includes a vararg list of include patterns
-     * @return this
-     * @see org.gradle.api.tasks.util.PatternFilterable Pattern Format
+     * @return this* @see org.gradle.api.tasks.util.PatternFilterable Pattern Format
      */
     @Override
     GithubPublish include(String... includes) {
@@ -292,8 +442,7 @@ class GithubPublish extends AbstractGithubTask implements GithubPublishSpec {
      * file must match at least one of the include patterns to be processed.
      *
      * @param includes a Iterable providing more include patterns
-     * @return this
-     * @see org.gradle.api.tasks.util.PatternFilterable Pattern Format
+     * @return this* @see org.gradle.api.tasks.util.PatternFilterable Pattern Format
      */
     @Override
     GithubPublish include(Iterable<String> includes) {
@@ -307,8 +456,7 @@ class GithubPublish extends AbstractGithubTask implements GithubPublishSpec {
      * file must match at least one of the include patterns or specs to be included.
      *
      * @param includeSpec the spec to add
-     * @return this
-     * @see org.gradle.api.tasks.util.PatternFilterable Pattern Format
+     * @return this* @see org.gradle.api.tasks.util.PatternFilterable Pattern Format
      */
     @Override
     GithubPublish include(Spec<FileTreeElement> includeSpec) {
@@ -324,12 +472,11 @@ class GithubPublish extends AbstractGithubTask implements GithubPublishSpec {
      * file must match at least one of the include patterns or specs to be included.
      *
      * @param includeSpec the spec to add
-     * @return this
-     * @see org.gradle.api.tasks.util.PatternFilterable Pattern Format
+     * @return this* @see org.gradle.api.tasks.util.PatternFilterable Pattern Format
      */
     @Override
     GithubPublish include(Closure includeSpec) {
-        this.include(Specs.<FileTreeElement>convertClosureToSpec(includeSpec))
+        this.include(Specs.<FileTreeElement> convertClosureToSpec(includeSpec))
     }
 
     /**
@@ -340,8 +487,7 @@ class GithubPublish extends AbstractGithubTask implements GithubPublishSpec {
      * any exclude pattern to be processed.
      *
      * @param excludes a vararg list of exclude patterns
-     * @return this
-     * @see org.gradle.api.tasks.util.PatternFilterable Pattern Format
+     * @return this* @see org.gradle.api.tasks.util.PatternFilterable Pattern Format
      */
     @Override
     GithubPublish exclude(String... excludes) {
@@ -357,8 +503,7 @@ class GithubPublish extends AbstractGithubTask implements GithubPublishSpec {
      * any exclude pattern to be processed.
      *
      * @param excludes a Iterable providing new exclude patterns
-     * @return this
-     * @see org.gradle.api.tasks.util.PatternFilterable Pattern Format
+     * @return this* @see org.gradle.api.tasks.util.PatternFilterable Pattern Format
      */
     @Override
     GithubPublish exclude(Iterable<String> excludes) {
@@ -372,8 +517,7 @@ class GithubPublish extends AbstractGithubTask implements GithubPublishSpec {
      * any exclude pattern to be processed.
      *
      * @param excludeSpec the spec to add
-     * @return this
-     * @see org.gradle.api.tasks.util.PatternFilterable Pattern Format
+     * @return this* @see org.gradle.api.tasks.util.PatternFilterable Pattern Format
      */
     @Override
     GithubPublish exclude(Spec<FileTreeElement> excludeSpec) {
@@ -386,24 +530,20 @@ class GithubPublish extends AbstractGithubTask implements GithubPublishSpec {
      * {@link org.gradle.api.file.FileTreeElement} as its parameter. The closure should return true or false. Example:
      *
      * <pre autoTested='true'>
-     * copySpec {
-     *   from 'source'
+     * copySpec {*   from 'source'
      *   into 'destination'
      *   //an example of excluding files from certain configuration:
-     *   exclude { it.file in configurations.someConf.files }
-     * }
-     * </pre>
+     *   exclude { it.file in configurations.someConf.files }*}* </pre>
      *
      * If excludes are not provided, then no files will be excluded. If excludes are provided, then files must not match
      * any exclude pattern to be processed.
      *
      * @param excludeSpec the spec to add
-     * @return this
-     * @see FileTreeElement
+     * @return this* @see FileTreeElement
      */
     @Override
     GithubPublish exclude(Closure excludeSpec) {
-        this.exclude(Specs.<FileTreeElement>convertClosureToSpec(excludeSpec))
+        this.exclude(Specs.<FileTreeElement> convertClosureToSpec(excludeSpec))
     }
 
     private Object tagName
@@ -413,6 +553,7 @@ class GithubPublish extends AbstractGithubTask implements GithubPublishSpec {
 
     private Object prerelease
     private Object draft
+    private Object publishMethod = PublishMethod.create
 
     /**
      * See: {@link GithubPublishSpec#getTagName()}
@@ -420,7 +561,7 @@ class GithubPublish extends AbstractGithubTask implements GithubPublishSpec {
     @Input
     @Override
     String getTagName() {
-        if(this.tagName == null) {
+        if (this.tagName == null) {
             return null
         }
 
@@ -469,9 +610,10 @@ class GithubPublish extends AbstractGithubTask implements GithubPublishSpec {
      * See: {@link GithubPublishSpec#getTargetCommitish()}
      */
     @Input
+    @Optional
     @Override
     String getTargetCommitish() {
-        if(this.targetCommitish == null) {
+        if (this.targetCommitish == null) {
             return null
         }
 
@@ -522,7 +664,7 @@ class GithubPublish extends AbstractGithubTask implements GithubPublishSpec {
     @Optional
     @Input
     String getReleaseName() {
-        if(this.releaseName == null) {
+        if (this.releaseName == null) {
             return null
         }
 
@@ -574,7 +716,7 @@ class GithubPublish extends AbstractGithubTask implements GithubPublishSpec {
     @Input
     @Override
     String getBody() {
-        if(this.body == null) {
+        if (this.body == null) {
             return null
         }
 
@@ -616,7 +758,7 @@ class GithubPublish extends AbstractGithubTask implements GithubPublishSpec {
      */
     @Override
     GithubPublish setBody(Closure closure) {
-        if(closure.maximumNumberOfParameters > 1) {
+        if (closure.maximumNumberOfParameters > 1) {
             throw new GradleException("Too many parameters for body clojure")
         }
 
@@ -757,4 +899,51 @@ class GithubPublish extends AbstractGithubTask implements GithubPublishSpec {
     GithubPublish draft(Object draft) {
         this.setDraft(draft)
     }
+
+    /**
+     * See: {@link GithubPublishSpec#getPublishMethod()}
+     */
+    @Override
+    PublishMethod getPublishMethod() {
+        if (this.publishMethod instanceof Callable) {
+            return ((Callable) this.publishMethod).call() as PublishMethod
+        }
+
+        this.publishMethod as PublishMethod
+    }
+
+    /**
+     * See: {@link GithubPublishSpec#setPublishMethod(PublishMethod)}
+     */
+    @Override
+    GithubPublishSpec setPublishMethod(PublishMethod method) {
+        this.publishMethod = method
+        this
+    }
+
+    /**
+     * See: {@link GithubPublishSpec#setPublishMethod(Object)}
+     */
+    @Override
+    GithubPublishSpec setPublishMethod(Object method) {
+        this.publishMethod = method
+        this
+    }
+
+    /**
+     * See: {@link GithubPublishSpec#setPublishMethod(PublishMethod)}
+     */
+    @Override
+    GithubPublishSpec publishMethod(PublishMethod method) {
+        this.setPublishMethod(method)
+    }
+
+    /**
+     * See: {@link GithubPublishSpec#setPublishMethod(Object)}
+     */
+    @Override
+    GithubPublishSpec publishMethod(Object method) {
+        this.setPublishMethod(method)
+    }
+
 }

--- a/src/test/groovy/wooga/gradle/github/publish/internal/GithubPublishRollbackHandlerSpec.groovy
+++ b/src/test/groovy/wooga/gradle/github/publish/internal/GithubPublishRollbackHandlerSpec.groovy
@@ -1,0 +1,135 @@
+/*
+ * Copyright 2019 Wooga GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package wooga.gradle.github.publish.internal
+
+import org.kohsuke.github.GHAsset
+import org.kohsuke.github.GHRelease
+import spock.lang.Specification
+import spock.lang.Unroll
+import wooga.gradle.github.publish.tasks.GithubPublish
+
+class GithubPublishRollbackHandlerSpec extends Specification {
+
+
+    @Unroll
+    def "rollback tries to deletes release and catches all errors"() {
+        given: "a delete counter"
+        def count = 0
+        and: "a release that might fail on delete"
+
+        release.delete() >> {
+            count++; if (deleteWillFail) {
+                throw new IOException("some error")
+            }
+        }
+
+        when:
+        GithubPublishRollbackHandler.rollback(release, deleteRelease, null)
+
+        then:
+        if (deleteRelease && release) {
+            count == 1
+        } else {
+            count == 0
+        }
+
+        noExceptionThrown()
+
+
+        where:
+        release         | deleteRelease | deleteWillFail
+        Mock(GHRelease) | true          | true
+        Mock(GHRelease) | true          | false
+        Mock(GHRelease) | false         | true
+        Mock(GHRelease) | false         | false
+        null            | true          | false
+        null            | false         | false
+    }
+
+    def "rollback deletes uploaded assets and throws no errors"() {
+        given: "a delete counter"
+        def count = 0
+
+        and: "a list of uploaded Assets"
+        List<GHAsset> assets = [Mock(GHAsset), Mock(GHAsset)]
+
+        and: "a release Mock"
+        def release = Mock(GHRelease)
+
+        and: "a delete method mock"
+        assets.each {
+            it.delete() >> {
+                count++; if (deleteWillFail) {
+                    throw new IOException()
+                }
+            }
+        }
+
+        and: "a GithubReleaseUploadAssetException cause"
+        def cause = new GithubReleaseUploadAssetException(assets, [], null)
+
+        and: "a generic error with assets cause as cause"
+        def error = new Exception("some exception", cause)
+
+        when:
+        GithubPublishRollbackHandler.rollback(release, false, error)
+
+        then:
+        noExceptionThrown()
+        count == 2
+
+        where:
+        deleteWillFail << [true, false]
+    }
+
+    def "rollback restores updated assets and throws no errors"() {
+        given: "a restore counter"
+        def count = 0
+
+        and: "a list of uploaded Assets"
+        List<GithubPublish.UpdatedAsset> assets = [Mock(GithubPublish.UpdatedAsset), Mock(GithubPublish.UpdatedAsset)]
+
+        and: "a release Mock"
+        def release = Mock(GHRelease)
+
+        and: "a delete method mock"
+        assets.each {
+            it.restore(release) >> {
+                count++; if (restoreWillFail) {
+                    throw new IOException()
+                }
+            }
+        }
+
+        and: "a GithubReleaseUploadAssetException cause"
+        def cause = new GithubReleaseUploadAssetException([], assets, null)
+
+        and: "a generic error with assets cause as cause"
+        def error = new Exception("some exception", cause)
+
+        when:
+        GithubPublishRollbackHandler.rollback(release, false, error)
+
+        then:
+        noExceptionThrown()
+        count == 2
+
+        where:
+        restoreWillFail << [true, false]
+    }
+}


### PR DESCRIPTION
Description
===========

For some publish workflows it would be nice to execute multiple github publish tasks on multiple gradle runs to support multi platform releases or integration of third party publish plugins which have their own workflows. Up until know the only way to publish artifacts from multiple platforms was to build them first and execute one build to create the release and upload the artifacts in one run. With this patch it is finally possible to configure the `GithubPublish` task type to `create`,`update` or `createOrUpdate` a release.

See a potential pipeline:

```
                                                                       builds in parallel
                                                                       +----------------+

                                                    +------------------------+    +-------------------+
                                                 +-->  build macOS binary    +----> publish binaries  +-+
                                                 |  +------------------------+    +-------------------+ |
                                                 |                                                      |
                                                 |                                                      |
                                                 |                                                      |
+-------------------+     +-------------------+  |  +------------------------+    +-------------------+ |   +-------------------+
|     run tests     +----->   draft release   +----^+  build windows binary  +----> publish binaries  +----->  publish release  |
+-------------------+     +-------------------+  |  +------------------------+    +-------------------+ |   +-------------------+
                                                 |                                                      |
                                                 |                                                      |
                                                 |                                                      |
                                                 |  +------------------------+    +-------------------+ |
                                                 +-->  build linux binary    +----> publish binaries  +-+
                                                    +------------------------+    +-------------------+

```

_the `draft release` step could also be done by the first `publish binaries` step.
First one drafts the release_

This patch includes some big changes in the `GithubPublish` task. I decided to implement the `update`/`create` handling inside the already know `GithubPublish` class. The steps of creating a release and updating it are not much different. The task already had some basic update
functionality to move it from `draft` to `published` state.

I increased the error handling code and release rollback logic, in order to deal with potential error cases during update of the release meta data or release assets.

Usage
-----

If you want to use this new functionality you have to instruct the gradle task `githubPublish` or your own custom task if you created one which publish method to use. There are three options:

| method         | description                                                                   |
| -------------- | ----------------------------------------------------------------------------- |
| create         | creates a new release and fails if one already exists. _This is the default__ |
| update         | updates a release and fails if it doesn't exist.                              |
| updateOrCreate | updates a release or creates it if not created already                        |

> Note: As the common key to find releases at github this plugin uses the `tagName` property. Github allows to update the `tagName` of a release but this plugin doesn't support this!

The `GithubPublish` task contains a new property `publishMethod` which can be set in the __build.gradle__

> Note: There is no default mapping from properties or environment variables available at this time. The `publishMethod` property can be used with a closure. This part will be rewritten when the `Provider` API in the future.

**build.gradle**
```
task testPublish(type:wooga.gradle.github.publish.tasks.GithubPublish) {
   from "fileToPublish"
   tagName = "$tagName"
   publishMethod = "update"
}
```

Changes
=======

![ADD] update releases feature

[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:http://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:http://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:http://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://resources.atlas.wooga.com/icons/icon_webGL.svg "Web:GL"
