### PR TITLE
Fix multiple calls to lazy body properties

### DIFF
--- a/src/integrationTest/groovy/wooga/gradle/github/GithubPublishPropertySpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/github/GithubPublishPropertySpec.groovy
@@ -18,6 +18,7 @@
 package wooga.gradle.github
 
 import org.kohsuke.github.GHRepository
+import spock.lang.Issue
 import spock.lang.Retry
 import spock.lang.Unroll
 import wooga.gradle.github.publish.PublishBodyStrategy
@@ -336,6 +337,58 @@ class GithubPublishPropertySpec extends GithubPublishIntegration {
         tagName = "v0.1.${Math.abs(new Random().nextInt() % 1000) + 1}-GithubPublishPropertySpec"
         versionName = tagName.replaceFirst('v', '')
         methodName = useSetter ? "set${method.capitalize()}" : method
+    }
+
+    @Issue("https://github.com/wooga/atlas-github/issues/31")
+    @Unroll
+    def "evaluates body property once"() {
+        given: "files to publish"
+        createTestAssetsToPublish(1)
+
+        and: "a buildfile with publish task"
+        buildFile << """
+            version "$versionName"
+
+            task testPublish(type:wooga.gradle.github.publish.tasks.GithubPublish) {
+                from "releaseAssets"
+                tagName = "$tagName"
+                repositoryName = "$testRepositoryName"
+                token = "$testUserToken"
+            }            
+        """.stripIndent()
+
+        buildFile << """
+            def callCounter = 0
+            
+            def publishBodyStrategy = new wooga.gradle.github.publish.PublishBodyStrategy() {
+                @Override
+                String getBody(org.kohsuke.github.GHRepository ghRepository) {
+                    callCounter = callCounter + 1
+                    return "evaluate body count: " + callCounter.toString()
+                }
+            }
+
+            testPublish.body(publishBodyStrategy)
+            
+            testPublish.doLast {
+                println("evaluate body count: " + callCounter.toString())
+            }
+        """.stripIndent()
+
+        when:
+        def result = runTasksSuccessfully("testPublish")
+
+        then:
+        hasReleaseByName(versionName)
+        def release = getReleaseByName(versionName)
+
+        release.getBody() == "evaluate body count: 1"
+        outputContains(result, "evaluate body count: 1")
+
+        where:
+        tagName = "v0.1.${Math.abs(new Random().nextInt() % 1000) + 1}-GithubPublishPropertySpec"
+        versionName = tagName.replaceFirst('v', '')
+
     }
 
     @Unroll

--- a/src/main/groovy/wooga/gradle/github/publish/tasks/GithubPublish.groovy
+++ b/src/main/groovy/wooga/gradle/github/publish/tasks/GithubPublish.groovy
@@ -676,6 +676,8 @@ class GithubPublish extends AbstractGithubTask implements GithubPublishSpec {
         this.setReleaseName(name)
     }
 
+    private String evaluatedBody
+
     /**
      * See: {@link GithubPublishSpec#getBody()}
      */
@@ -683,20 +685,27 @@ class GithubPublish extends AbstractGithubTask implements GithubPublishSpec {
     @Input
     @Override
     String getBody() {
+        if(evaluatedBody) {
+            return evaluatedBody
+        }
+
         if (this.body == null) {
             return null
         }
 
         if (this.body instanceof Closure) {
-            return ((Closure) this.body).call(getRepository(getClient())).toString()
+            evaluatedBody = ((Closure) this.body).call(getRepository(getClient())).toString()
+            return evaluatedBody
         }
 
         if (this.body instanceof PublishBodyStrategy) {
-            return ((PublishBodyStrategy) this.body).getBody(getRepository(getClient()))
+            evaluatedBody = ((PublishBodyStrategy) this.body).getBody(getRepository(getClient()))
+            return evaluatedBody
         }
 
         if (this.body instanceof Callable) {
-            return ((Callable) this.body).call().toString()
+            evaluatedBody = ((Callable) this.body).call().toString()
+            return evaluatedBody
         }
 
         this.body.toString()


### PR DESCRIPTION
## Description

As reported in [issue 31], the `PublishBodyStrategy` is invoked multiple times during execution of the publish task. This patch adds a regression test and a small fix to cache the evaluated body value.

## Changes

![FIX] multiple calls to `PublishBodyStrategy`

[issue 31]:    https://github.com/wooga/atlas-github/issues/31


[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:http://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:http://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:http://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://resources.atlas.wooga.com/icons/icon_webGL.svg "Web:GL"
