### PR TITLE
Fix multiple calls to lazy body properties (2.x)

### DIFF
--- a/src/main/groovy/wooga/gradle/github/publish/tasks/GithubPublish.groovy
+++ b/src/main/groovy/wooga/gradle/github/publish/tasks/GithubPublish.groovy
@@ -665,32 +665,6 @@ class GithubPublish extends AbstractGithubTask implements GithubPublishSpec {
         this.setReleaseName(name)
     }
 
-//    /**
-//     * See: {@link GithubPublishSpec#getBody()}
-//     */
-//    @Optional
-//    @Input
-//    @Override
-//    String getBody() {
-//        if (this.body == null) {
-//            return null
-//        }
-//
-//        if (this.body instanceof Closure) {
-//            return ((Closure) this.body).call(getRepository(getClient())).toString()
-//        }
-//
-//        if (this.body instanceof PublishBodyStrategy) {
-//            return ((PublishBodyStrategy) this.body).getBody(getRepository(getClient()))
-//        }
-//
-//        if (this.body instanceof Callable) {
-//            return ((Callable) this.body).call().toString()
-//        }
-//
-//        this.body.toString()
-//    }
-
     /**
      * See: {@link GithubPublishSpec#setBody(String)}
      */
@@ -707,7 +681,9 @@ class GithubPublish extends AbstractGithubTask implements GithubPublishSpec {
     GithubPublish setBody(Object body) {
         this.body.set(project.provider({
             if (body instanceof Callable) {
-                return ((Callable) body).call().toString()
+                String evaluatedBody = ((Callable) body).call().toString()
+                this.body.set(evaluatedBody)
+                evaluatedBody
             }
 
             body.toString()
@@ -725,7 +701,9 @@ class GithubPublish extends AbstractGithubTask implements GithubPublishSpec {
         }
 
         this.body.set(project.provider({
-            closure.call(getRepository()).toString()
+            String evaluatedBody = closure.call(getRepository()).toString()
+            this.body.set(evaluatedBody)
+            evaluatedBody
         }))
         this
     }
@@ -735,7 +713,9 @@ class GithubPublish extends AbstractGithubTask implements GithubPublishSpec {
      */
     GithubPublish setBody(PublishBodyStrategy bodyStrategy) {
         this.body.set(project.provider({
-            bodyStrategy.getBody(getRepository())
+            String evaluatedBody = bodyStrategy.getBody(getRepository())
+            this.body.set(evaluatedBody)
+            evaluatedBody
         }))
         this
     }


### PR DESCRIPTION
## Description

As reported in [issue 31], the `PublishBodyStrategy` is invoked multiple times during execution of the publish task. This patch adds a regression test and a small fix to cache the evaluated body value.

## Changes

![FIX] multiple calls to `PublishBodyStrategy`

[issue 31]:    https://github.com/wooga/atlas-github/issues/31


[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:http://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:http://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:http://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://resources.atlas.wooga.com/icons/icon_webGL.svg "Web:GL"
