### PR TITLE
Fix missing task file input declaration (2.x)

### DIFF
--- a/src/main/groovy/wooga/gradle/github/publish/tasks/GithubPublish.groovy
+++ b/src/main/groovy/wooga/gradle/github/publish/tasks/GithubPublish.groovy
@@ -21,7 +21,9 @@ import groovy.io.FileType
 import groovy.json.JsonSlurper
 import org.apache.commons.io.FileUtils
 import org.gradle.api.Action
+import org.gradle.api.Buildable
 import org.gradle.api.GradleException
+import org.gradle.api.Task
 import org.gradle.api.file.CopySpec
 import org.gradle.api.file.FileTreeElement
 import org.gradle.api.logging.Logger
@@ -339,6 +341,7 @@ class GithubPublish extends AbstractGithubTask implements GithubPublishSpec {
      */
     @Override
     GithubPublish from(Object... sourcePaths) {
+        this.inputs.files(sourcePaths)
         assetsCopySpec.from(sourcePaths)
         processAssets = true
         this
@@ -366,6 +369,7 @@ class GithubPublish extends AbstractGithubTask implements GithubPublishSpec {
      */
     @Override
     GithubPublish from(Object sourcePath, Action<? super CopySpec> configureAction) {
+        this.inputs.files(sourcePath)
         assetsCopySpec.from(sourcePath, configureAction)
         processAssets = true
         this


### PR DESCRIPTION
## Description

The `CopySpec` allows to define source path declarations from multiple sources. If the input is a task or a configuration gradle would normally execute the tasks to produce the connected artifacts. As pointed out in [issue 30] the publish tasks missed a declaration step to tell gradle to connect these input/outputs.

## Changes

![FIX] missing file input declaration

[issue 30]: https://github.com/wooga/atlas-github/issues/30

[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:http://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:http://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:http://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://resources.atlas.wooga.com/icons/icon_webGL.svg "Web:GL"
