### PR TITLE
Improve publish body input parameter handling

### DIFF
--- a/src/main/groovy/wooga/gradle/github/publish/tasks/GithubPublish.groovy
+++ b/src/main/groovy/wooga/gradle/github/publish/tasks/GithubPublish.groovy
@@ -712,6 +712,22 @@ class GithubPublish extends AbstractGithubTask implements GithubPublishSpec {
             return evaluatedBody
         }
 
+        if (this.body instanceof File) {
+            evaluatedBody = ((File) this.body).text
+            return evaluatedBody
+        }
+
+        if (this.body instanceof Task) {
+            def task = this.body as Task
+            def outputs = task.outputs
+            if(outputs.hasOutput) {
+                evaluatedBody = outputs.files.singleFile.text
+                return evaluatedBody
+            } else {
+                throw new GradleException("Task provided as body input has no outputs")
+            }
+        }
+
         this.body.toString()
     }
 
@@ -729,6 +745,7 @@ class GithubPublish extends AbstractGithubTask implements GithubPublishSpec {
      */
     @Override
     GithubPublish setBody(Object body) {
+        this.inputs.file(body)
         this.body = body
         this
     }


### PR DESCRIPTION
## Description

This patch improves the handling of body property in `GithubPublish`. With this change it is possible to provide a `File` or `Task` as the input for the body property. A `File` object will be evaluated and read during runtime and set as input file.

If the body value is of type `Task`, the task outputs will be evaluated at runtime. The task will fail if the provided task has to no or too many output files configured.

## Changes

![IMPROVE] publish body input parameter

[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:http://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:http://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:http://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://resources.atlas.wooga.com/icons/icon_webGL.svg "Web:GL"
