### PR TITLE
Improve publish body input parameter handling

### DIFF
--- a/src/integrationTest/groovy/wooga/gradle/github/GithubPublishPropertySpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/github/GithubPublishPropertySpec.groovy
@@ -24,7 +24,7 @@ import spock.lang.Unroll
 import wooga.gradle.github.publish.PublishBodyStrategy
 import wooga.gradle.github.publish.PublishMethod
 
-@Retry(mode=Retry.Mode.SETUP_FEATURE_CLEANUP)
+@Retry(mode = Retry.Mode.SETUP_FEATURE_CLEANUP)
 class GithubPublishPropertySpec extends GithubPublishIntegration {
 
     def "task skips if repository is not set"() {
@@ -149,6 +149,121 @@ class GithubPublishPropertySpec extends GithubPublishIntegration {
         methodValue = isLazy ? "closure" : "value"
         preValue = isLazy ? "{" : ""
         postValue = isLazy ? "}" : ""
+        tagName = "v0.1.${Math.abs(new Random().nextInt() % 1000) + 1}-GithubPublishPropertySpec"
+        versionName = tagName.replaceFirst('v', '')
+    }
+
+    @Unroll
+    def "can set body with #valueType and #methodName"() {
+        given: "files to publish"
+        createTestAssetsToPublish(1)
+
+        and: "a buildfile with publish task"
+        buildFile << """
+        version "$versionName"
+
+        task testPublish(type:wooga.gradle.github.publish.tasks.GithubPublish) {
+            from "releaseAssets"
+            tagName = "$tagName"
+            repositoryName = "$testRepositoryName"
+            token = "$testUserToken"
+        }
+        """.stripIndent()
+
+        if (valueType == "File") {
+            createFile("test_body.md", projectDir).text = bodyValue
+
+            buildFile << """
+            testPublish.$methodName(file("test_body.md"))
+            """.stripIndent()
+        }
+
+        if (valueType == "Task") {
+            buildFile << """
+
+            task generateBody {
+                outputs.file("body_from_task.md")
+                doLast {
+                    file("body_from_task.md").text = "$bodyValue"
+                }
+            }
+
+            testPublish.$methodName(generateBody)
+            """.stripIndent()
+        }
+
+        when:
+        def result = runTasksSuccessfully("testPublish")
+
+        then:
+        if (valueType == "Task") {
+            result.wasExecuted("generateBody")
+        }
+
+        hasReleaseByName(versionName)
+        def release = getReleaseByName(versionName)
+        release.getBody() == bodyValue
+
+        where:
+        bodyValue           | useSetter | valueType
+        "test body as file" | false     | "File"
+        "test body as file" | true      | "File"
+        "test body as task" | false     | "Task"
+        "test body as task" | true      | "Task"
+
+        method = "body"
+        methodName = useSetter ? "set${method.capitalize()}" : method
+        tagName = "v0.1.${Math.abs(new Random().nextInt() % 1000) + 1}-GithubPublishPropertySpec"
+        versionName = tagName.replaceFirst('v', '')
+    }
+
+    @Unroll
+    def "fails to evalute body from task when #reason"() {
+        given: "files to publish"
+        createTestAssetsToPublish(1)
+
+        and: "a buildfile with publish task"
+        buildFile << """
+        version "$versionName"
+
+        task testPublish(type:wooga.gradle.github.publish.tasks.GithubPublish) {
+            from "releaseAssets"
+            tagName = "$tagName"
+            repositoryName = "$testRepositoryName"
+            token = "$testUserToken"
+        }
+        """.stripIndent()
+
+        and: "a task with potential body outputs"
+        buildFile << """
+        task generateBody
+        testPublish.body(generateBody)
+        """.stripIndent()
+
+        and: "optional outputs"
+
+        (0..<numberOfOutputs).each { i ->
+            buildFile << """
+            generateBody {
+                outputs.file("body_from_task_${i}.md")
+                doLast {
+                    file("body_from_task_${i}.md").text = "random value"
+                }
+            }
+            """.stripIndent()
+        }
+
+        when:
+        def result = runTasksWithFailure("testPublish")
+
+        then:
+        outputContains(result, expectedError)
+
+        where:
+        reason                      | numberOfOutputs | expectedError
+        "task has no outputs"       | 0               | "Task provided as body input has no outputs"
+        "task has too many outputs" | 2               | "output files to contain exactly one file, however, it contains more than one file"
+
         tagName = "v0.1.${Math.abs(new Random().nextInt() % 1000) + 1}-GithubPublishPropertySpec"
         versionName = tagName.replaceFirst('v', '')
     }
@@ -503,7 +618,7 @@ class GithubPublishPropertySpec extends GithubPublishIntegration {
         createTestAssetsToPublish(1)
 
         and: "optional release"
-        if(publishMethod == PublishMethod.update) {
+        if (publishMethod == PublishMethod.update) {
             createRelease(tagName)
         }
 

--- a/src/main/groovy/wooga/gradle/github/publish/GithubPublishSpec.groovy
+++ b/src/main/groovy/wooga/gradle/github/publish/GithubPublishSpec.groovy
@@ -17,6 +17,7 @@
 
 package wooga.gradle.github.publish
 
+import org.gradle.api.Task
 import org.gradle.api.file.CopySourceSpec
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.util.PatternFilterable
@@ -212,9 +213,35 @@ interface GithubPublishSpec extends GithubSpec, CopySourceSpec, PatternFilterabl
      * The repository object can be used to query the Git commit log or pull requests etc.
      *
      * @param bodyStrategy an object of type {@link PublishBodyStrategy} which returns the release description
-     * @return this* @see PublishBodyStrategy#getBody(org.kohsuke.github.GHRepository)
+     * @return this
+     * @see PublishBodyStrategy#getBody(org.kohsuke.github.GHRepository)
      */
     GithubPublishSpec setBody(PublishBodyStrategy bodyStrategy)
+
+    /**
+     * Sets the description text for the release.
+     * <p>
+     * This setter allows to set a {@code File} property as the provider for the release body property.
+     * The content of the file is read at runtime of the task.
+     *
+     * @param body a {@code File} which contains the body text
+     * @return this
+     */
+    GithubPublishSpec setBody(File body)
+
+    /**
+     * Sets the description text for the release.
+     * <p>
+     * This setter allows to set a {@code Task} property as the provider for the release body property.
+     * The task outputs will be evaluated at runtime. The task should only produce a single output file which
+     * will be read and set as the release body value.
+     * <p>
+     * If the task produces no outputs or more than one, the publish task will fail.
+     *
+     * @param body a {@code File} which contains the body text
+     * @return this
+     */
+    GithubPublishSpec setBody(Task body)
 
     /**
      * Sets the description text for the release.
@@ -253,6 +280,31 @@ interface GithubPublishSpec extends GithubSpec, CopySourceSpec, PatternFilterabl
      * @return this* @see PublishBodyStrategy#getBody(org.kohsuke.github.GHRepository)
      */
     GithubPublishSpec body(PublishBodyStrategy bodyStrategy)
+
+    /**
+     * Sets the description text for the release.
+     * <p>
+     * This setter allows to set a {@code File} property as the provider for the release body property.
+     * The content of the file is read at runtime of the task.
+     *
+     * @param body a {@code File} which contains the body text
+     * @return this
+     */
+    GithubPublishSpec body(File body)
+
+    /**
+     * Sets the description text for the release.
+     * <p>
+     * This setter allows to set a {@code Task} property as the provider for the release body property.
+     * The task outputs will be evaluated at runtime. The task should only produce a single output file which
+     * will be read and set as the release body value.
+     * <p>
+     * If the task produces no outputs or more than one, the publish task will fail.
+     *
+     * @param body a {@code File} which contains the body text
+     * @return this
+     */
+    GithubPublishSpec body(Task body)
 
     /**
      * Returns a {@code boolean} value indicating if the release as a prerelease.


### PR DESCRIPTION
## Description

This patch improves the handling of body property in `GithubPublish`. With this change it is possible to provide a `File` or `Task` as the input for the body property. A `File` object will be evaluated and read during runtime and set as input file.

If the body value is of type `Task`, the task outputs will be evaluated at runtime. The task will fail if the provided task has to no or too many output files configured.

## Changes

![IMPROVE] publish body input parameter

[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:http://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:http://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:http://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://resources.atlas.wooga.com/icons/icon_webGL.svg "Web:GL"
