### PR TITLE
Improve integration tests with external spock extension

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -50,4 +50,6 @@ dependencies {
     testCompile('com.nagternal:spock-genesis:0.6.0') {
         exclude group: "org.codehaus.groovy", module: "groovy-all"
     }
+
+    testCompile 'com.wooga.spock.extensions:spock-github-extension:0.1.0'
 }

--- a/src/integrationTest/groovy/wooga/gradle/github/GithubIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/github/GithubIntegrationSpec.groovy
@@ -75,7 +75,7 @@ class GithubIntegrationSpec extends GithubPublishIntegrationWithDefaultAuth {
 
     def "can update files and content of repository"() {
         given: "a test file in the created repo"
-        testRepo.createContent(initialContent, "add empty release notes", file)
+        createContent(initialContent, "add empty release notes", file)
 
 
         and: "an action inside customGithubTask which changes this new file"


### PR DESCRIPTION
## Description

This patch integrates a spock extension library to bootrstrap the creation and destruction of test github repositories.

To limit the amount of changes in the tests, I created some delegate methods and getters.

## Changes

![IMPROVE] integration tests with [spock-github-extension]

[spock-github-extension]: https://github.com/wooga/spock-github-extension

[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:http://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:http://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:http://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://resources.atlas.wooga.com/icons/icon_webGL.svg "Web:GL"
