### PR TITLE
Fix NullPointerException during exception throw

### DIFF
--- a/src/integrationTest/groovy/wooga/gradle/github/GithubPublishIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/github/GithubPublishIntegrationSpec.groovy
@@ -379,7 +379,7 @@ class GithubPublishIntegrationSpec extends GithubPublishIntegrationWithDefaultAu
         expectedBody = "Updated Body"
         expectedPrerelease = false
         expectedDraft = false
-        expectedTargetCommitish = "master"
+        expectedTargetCommitish = testRepo.defaultBranch.name
 
         initialName = expectedName.replace("Update", "Initial")
         initialBody = expectedBody.replace("Update", "Initial")

--- a/src/integrationTest/groovy/wooga/gradle/github/GithubPublishPropertySpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/github/GithubPublishPropertySpec.groovy
@@ -104,7 +104,7 @@ class GithubPublishPropertySpec extends GithubPublishIntegration {
 
         then:
         def releaseValueCheck = releaseNameValue ? releaseNameValue : versionName
-        def targetCommitishValueCheck = targetCommitishValue ? targetCommitishValue : "master"
+        def targetCommitishValueCheck = targetCommitishValue ? targetCommitishValue : testRepo.defaultBranch.name
 
         hasReleaseByName(releaseValueCheck)
         def release = getReleaseByName(releaseValueCheck)

--- a/src/main/groovy/wooga/gradle/github/publish/GithubPublishPlugin.groovy
+++ b/src/main/groovy/wooga/gradle/github/publish/GithubPublishPlugin.groovy
@@ -89,7 +89,7 @@ class GithubPublishPlugin implements Plugin<Project> {
             void execute(GithubPublish task) {
                 ConventionMapping taskConventionMapping = task.getConventionMapping()
 
-                taskConventionMapping.map("targetCommitish", { "master" })
+                taskConventionMapping.map("targetCommitish", { null })
                 taskConventionMapping.map("prerelease", { false })
                 taskConventionMapping.map("draft", { false })
                 taskConventionMapping.map("tagName", { project.version.toString() })

--- a/src/main/groovy/wooga/gradle/github/publish/tasks/GithubPublish.groovy
+++ b/src/main/groovy/wooga/gradle/github/publish/tasks/GithubPublish.groovy
@@ -275,7 +275,7 @@ class GithubPublish extends AbstractGithubTask implements GithubPublishSpec {
             try {
                 result = setReleasePropertiesAndCommit(releasePropertySet)
             } catch (Exception error) {
-                throw new GithubReleaseCreateException("failed to create release ${release.tagName}", error)
+                throw new GithubReleaseCreateException("failed to create release ${getTagName()}", error)
             }
         }
         result


### PR DESCRIPTION
## Description

This is a potential copy paste error. The object `release` is null at the time when the publish step might throw an error. The patch simply takes the tag name from the internal property instead of the release object.

## Changes

* ![FIX] `NullPointerException` during exception throw

[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:http://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:http://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:http://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://resources.atlas.wooga.com/icons/icon_webGL.svg "Web:GL"
