### PR TITLE
Fix default value for targetCommitish property

### DIFF
--- a/src/integrationTest/groovy/wooga/gradle/github/GithubPublishIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/github/GithubPublishIntegrationSpec.groovy
@@ -379,7 +379,7 @@ class GithubPublishIntegrationSpec extends GithubPublishIntegrationWithDefaultAu
         expectedBody = "Updated Body"
         expectedPrerelease = false
         expectedDraft = false
-        expectedTargetCommitish = "master"
+        expectedTargetCommitish = testRepo.defaultBranch.name
 
         initialName = expectedName.replace("Update", "Initial")
         initialBody = expectedBody.replace("Update", "Initial")

--- a/src/integrationTest/groovy/wooga/gradle/github/GithubPublishPropertySpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/github/GithubPublishPropertySpec.groovy
@@ -104,7 +104,7 @@ class GithubPublishPropertySpec extends GithubPublishIntegration {
 
         then:
         def releaseValueCheck = releaseNameValue ? releaseNameValue : versionName
-        def targetCommitishValueCheck = targetCommitishValue ? targetCommitishValue : "master"
+        def targetCommitishValueCheck = targetCommitishValue ? targetCommitishValue : testRepo.defaultBranch.name
 
         hasReleaseByName(releaseValueCheck)
         def release = getReleaseByName(releaseValueCheck)

--- a/src/main/groovy/wooga/gradle/github/publish/GithubPublishPlugin.groovy
+++ b/src/main/groovy/wooga/gradle/github/publish/GithubPublishPlugin.groovy
@@ -89,7 +89,7 @@ class GithubPublishPlugin implements Plugin<Project> {
             void execute(GithubPublish task) {
                 ConventionMapping taskConventionMapping = task.getConventionMapping()
 
-                taskConventionMapping.map("targetCommitish", { "master" })
+                taskConventionMapping.map("targetCommitish", { null })
                 taskConventionMapping.map("prerelease", { false })
                 taskConventionMapping.map("draft", { false })
                 taskConventionMapping.map("tagName", { project.version.toString() })


### PR DESCRIPTION
## Description

This plugin assumed that the best default value for the targetCommitish property should be `master`. That is wrong for multiple reasons:

1. it's not written in stone what the default branch for a github repo is
2. github themselve changed the default value to `main` in summer 2020

This patch changes this optional value to `null` so that github will use the default branch name without this plugin setting any value beforehand.

Changes
=======

* ![FIX] default value for `targetCommitish` property

[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:http://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:http://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:http://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://resources.atlas.wooga.com/icons/icon_webGL.svg "Web:GL"
