### PR TITLE
Added client provider to extension

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -49,7 +49,7 @@ dependencies {
         exclude group: "org.codehaus.groovy", module: "groovy-all"
     }
 
-    testImplementation('com.wooga.spock.extensions:spock-github-extension:0.1.2') {
+    testImplementation('com.wooga.spock.extensions:spock-github-extension:0.2.0') {
         exclude group: "org.codehaus.groovy", module: "groovy-all"
     }
 }

--- a/src/integrationTest/groovy/wooga/gradle/github/GithubAuthenticationIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/github/GithubAuthenticationIntegrationSpec.groovy
@@ -167,4 +167,25 @@ class GithubAuthenticationIntegrationSpec extends AbstractGithubIntegrationSpec 
 //        testUserName | null          | testUserToken | "https://api.github.com" | "username/token/baseUrl"
 //        null         | null          | testUserToken | "https://api.github.com" | "token/baseUrl"
     }
+
+    def "gets client from set up credentials"() {
+        given:
+        buildFile << """
+            github {
+                username="${testRepo.userName}"
+                token="${testRepo.token}"
+            }
+            task(custom) {
+                doLast {
+                    def client = github.clientProvider.get()
+                    println("Repository: " + client.getRepository("${testRepo.repository.fullName}").fullName)
+                }
+            }            
+        """
+        when:
+        def result = runTasksSuccessfully("custom")
+
+        then:
+        result.standardOutput.contains("Repository: ${testRepo.repository.fullName}".toString())
+    }
 }

--- a/src/main/groovy/wooga/gradle/github/base/GithubBasePlugin.groovy
+++ b/src/main/groovy/wooga/gradle/github/base/GithubBasePlugin.groovy
@@ -91,6 +91,7 @@ class GithubBasePlugin implements Plugin<Project> {
             task.username.set(extension.username)
             task.password.set(extension.password)
             task.token.set(extension.token)
+            task.clientProvider.convention(extension.clientProvider)
         }
     }
 }

--- a/src/main/groovy/wooga/gradle/github/base/GithubSpec.groovy
+++ b/src/main/groovy/wooga/gradle/github/base/GithubSpec.groovy
@@ -19,6 +19,8 @@ package wooga.gradle.github.base
 
 import org.gradle.api.provider.Property
 import org.gradle.api.provider.Provider
+import org.kohsuke.github.GHRepository
+import org.kohsuke.github.GitHub
 
 /**
  * Base Task spec definitions for a github tasks/actions.
@@ -129,7 +131,22 @@ interface GithubSpec {
      * Sets the github access token.
      *
      * @param token the token. Must not be {@code Null} or {@code empty}
-     * @return this* @throws IllegalArgumentException
+     * @return this
+     * @throws IllegalArgumentException
      */
     void setToken(Provider<String> token)
+
+    /**
+     * Gets a client for github REST API operations, using
+     * credential providers set on this object in the following order:
+     * 1. username and password,
+     * 2. username and token
+     * 3. token,
+     * 4. external credentials (environment variables, .github file, etc)
+     *
+     * See org.kohsuke.github.GitHub for more details on the client.
+     * @return Provider for github client with given credentials
+     * @throws IOException if no credentials are found
+     */
+    Provider<GitHub> getClientProvider()
 }

--- a/src/main/groovy/wooga/gradle/github/base/internal/DefaultGithubPluginExtension.groovy
+++ b/src/main/groovy/wooga/gradle/github/base/internal/DefaultGithubPluginExtension.groovy
@@ -20,8 +20,9 @@ package wooga.gradle.github.base.internal
 import org.gradle.api.Project
 import org.gradle.api.provider.Property
 import org.gradle.api.provider.Provider
+import org.gradle.api.tasks.Internal
+import org.kohsuke.github.GitHub
 import wooga.gradle.github.base.GithubPluginExtension
-import wooga.gradle.github.base.GithubSpec
 
 class DefaultGithubPluginExtension implements GithubPluginExtension {
 
@@ -54,10 +55,18 @@ class DefaultGithubPluginExtension implements GithubPluginExtension {
     void setToken(Provider<String> token) {
         this.token.set(token)
     }
-    private final Closure property
+    @Override @Internal
+    Provider<GitHub> getClientProvider() {
+        return GithubClientFactory.clientProvider(username, password, token).
+        orElse(project.provider {
+          throw new IOException("could not find valid credentials for github client")
+        })
+    }
+
+    private final Project project
 
     DefaultGithubPluginExtension(Project project) {
-        this.property = project.&findProperty
+        this.project = project
 
         repositoryName = project.objects.property(String)
         baseUrl = project.objects.property(String)
@@ -65,12 +74,4 @@ class DefaultGithubPluginExtension implements GithubPluginExtension {
         password = project.objects.property(String)
         token = project.objects.property(String)
     }
-
-
-
-
-
-
-
-
 }

--- a/src/main/groovy/wooga/gradle/github/base/internal/GithubClientFactory.groovy
+++ b/src/main/groovy/wooga/gradle/github/base/internal/GithubClientFactory.groovy
@@ -1,0 +1,50 @@
+package wooga.gradle.github.base.internal
+
+
+import org.gradle.api.provider.Provider
+import org.kohsuke.github.GitHub
+import org.kohsuke.github.GitHubBuilder
+import wooga.gradle.github.base.GithubPluginExtension
+
+class GithubClientFactory {
+
+    static Provider<GitHub> clientProvider(Provider<String> username,
+                                           Provider<String> password,
+                                           Provider<String> token) {
+        //a non-empty provider if any credentials are available
+        Provider hasCredsProvider = username.orElse(password).orElse(token).orElse("").
+        map({
+            return it == "" && !hasExternalCredentials()? null : true
+        }.memoize())
+        return hasCredsProvider.map({
+            return new GithubClientFactory().
+                    createGithubClient(username.getOrNull(), password.getOrNull(), token.getOrNull())
+        }.memoize())
+    }
+
+    private static boolean hasExternalCredentials() {
+        try {
+            GitHubBuilder.fromCredentials()
+            return true
+        } catch(IOException _) {
+            return false
+        }
+    }
+
+    GitHub createGithubClient(String username, String password, String token) {
+        def builder = new GitHubBuilder()
+
+        if (username && password) {
+            builder = builder.withPassword(username, password)
+        } else if (username && token) {
+            builder = builder.withOAuthToken(token, username)
+
+        } else if (token) {
+            builder = builder.withOAuthToken(token)
+
+        } else {
+            builder = GitHubBuilder.fromCredentials()
+        }
+        return builder.build()
+    }
+}


### PR DESCRIPTION
## Description
Added client provider to GithubPluginExtension, which gives a github API client to be used, based on the extension credentials. As this would result in duplicated client initialization code, client initialization was centralized in `GithubClientFactory`, which returns an empty provider in case of missing credentials, so if you want to throw exception on empty provider, you must explicitly do so.


Also relocated some annotations on `AbstractGithubTask` to make it gradle 7 compatible.

## Changes
* ![ADD] clientProvider property to `GithubPluginExtension`.




[NEW]:https://resources.atlas.wooga.com/icons/icon_new.svg "New"
[ADD]:http://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:http://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:http://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://resources.atlas.wooga.com/icons/icon_webGL.svg "Web:GL"
