### PR TITLE
Adds branch name property to extension, and repositoryName may now be fetched automatically

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,6 +44,7 @@ dependencies {
     implementation 'org.kohsuke:github-api:1.131'
     implementation 'org.zeroturnaround:zt-zip:1.14'
     implementation 'org.apache.tika:tika-core:1.24.1'
+    implementation 'org.ajoberstar.grgit:grgit-core:4.1.0'
 
     testImplementation('com.nagternal:spock-genesis:0.6.0') {
         exclude group: "org.codehaus.groovy", module: "groovy-all"

--- a/src/integrationTest/groovy/wooga/gradle/github/GithubAuthenticationIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/github/GithubAuthenticationIntegrationSpec.groovy
@@ -188,4 +188,5 @@ class GithubAuthenticationIntegrationSpec extends AbstractGithubIntegrationSpec 
         then:
         result.standardOutput.contains("Repository: ${testRepo.repository.fullName}".toString())
     }
+
 }

--- a/src/integrationTest/groovy/wooga/gradle/github/GithubPluginExtensionIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/github/GithubPluginExtensionIntegrationSpec.groovy
@@ -28,7 +28,7 @@ class GithubPluginExtensionIntegrationSpec extends IntegrationSpec {
         ${applyPlugin(GithubPlugin)}
         """.stripIndent()
         git = Grgit.init(dir: projectDir)
-        def remoteURL = "https://github.com/${remoteRepo}"
+        def remoteURL = "https://github.com/${remoteRepo}.git"
         git.remote.add(name: "origin", url: remoteURL, pushUrl: remoteURL)
         git.commit(message: "initial")
         git.checkout(branch: currentBranch, createBranch: true)

--- a/src/integrationTest/groovy/wooga/gradle/github/GithubPluginExtensionIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/github/GithubPluginExtensionIntegrationSpec.groovy
@@ -1,14 +1,37 @@
 package wooga.gradle.github
 
-
+import org.ajoberstar.grgit.Grgit
+import spock.lang.Shared
 import spock.lang.Unroll
+import static wooga.gradle.github.base.GithubBasePluginConvention.*
 
 class GithubPluginExtensionIntegrationSpec extends IntegrationSpec {
+
+    @Shared
+    String currentBranch
+    @Shared
+    String remoteRepo
+    @Shared
+    Grgit git
+
+    def setupSpec() {
+        remoteRepo = "owner/repo"
+        currentBranch = "branch"
+    }
+
+    def cleanupSpec() {
+        git.close()
+    }
 
     def setup() {
         buildFile << """
         ${applyPlugin(GithubPlugin)}
         """.stripIndent()
+        git = Grgit.init(dir: projectDir)
+        def remoteURL = "https://github.com/${remoteRepo}"
+        git.remote.add(name: "origin", url: remoteURL, pushUrl: remoteURL)
+        git.commit(message: "initial")
+        git.checkout(branch: currentBranch, createBranch: true)
     }
 
     enum PropertyLocation {
@@ -96,7 +119,7 @@ class GithubPluginExtensionIntegrationSpec extends IntegrationSpec {
         "repositoryName" | "repositoryName.set" | "testUser/testRepo"        | _             | "Provider<String>" | PropertyLocation.script   | ""
         "repositoryName" | "setRepositoryName"  | "testUser/testRepo"        | _             | "String"           | PropertyLocation.script   | ""
         "repositoryName" | "setRepositoryName"  | "testUser/testRepo"        | _             | "Provider<String>" | PropertyLocation.script   | ""
-        "repositoryName" | _                    | _                          | null          | _                  | PropertyLocation.none     | ""
+        "repositoryName" | _                    | null                       | remoteRepo    | _                  | PropertyLocation.none     | ""
 
         "username"       | _                    | "someUser2"                | _             | _                  | PropertyLocation.property | ""
         "username"       | _                    | "someUser3"                | _             | "String"           | PropertyLocation.script   | ""
@@ -134,6 +157,8 @@ class GithubPluginExtensionIntegrationSpec extends IntegrationSpec {
         "baseUrl"        | "setBaseUrl"         | "https://api.github.com/8" | _             | "Provider<String>" | PropertyLocation.script   | ""
         "baseUrl"        | _                    | _                          | null          | _                  | PropertyLocation.none     | ""
 
+        "branchName"     | _                    | null                       | currentBranch | _                  | PropertyLocation.none     | ""
+
         extensionName = "github"
         value = (type != _) ? wrapValueBasedOnType(rawValue, type.toString()) : rawValue
         providedValue = (location == PropertyLocation.script) ? type : value
@@ -142,4 +167,32 @@ class GithubPluginExtensionIntegrationSpec extends IntegrationSpec {
         escapedValue = (value instanceof String) ? escapedPath(value) : value
         invocation = (method != _) ? "${method}(${escapedValue})" : "${property} = ${escapedValue}"
     }
+
+    @Unroll
+    def "extension property #extProperty should return value #value when set as gradle property #gradleProperty"() {
+        given:
+        buildFile << """
+            task(custom) {
+                doLast {
+                    def value = ${extensionName}.${extProperty}.getOrNull()
+                    println("${extensionName}.${extProperty}: " + value)
+                }
+            }
+        """
+        when:
+        def result = runTasksSuccessfully("custom", "-P${gradleProperty}=${value}")
+        then:
+        result.standardOutput.contains("${extensionName}.${extProperty}: ${value}")
+
+        where:
+        extProperty      | gradleProperty                | value
+        "repositoryName" | GITHUB_REPOSITORY_NAME_OPTION | "owner/reponame"
+        "username"       | GITHUB_USER_NAME_OPTION       | "user"
+        "password"       | GITHUB_USER_PASSWORD_OPTION   | "pword"
+        "token"          | GITHUB_TOKEN_OPTION           | "tkn"
+        "baseUrl"        | GITHUB_BASE_URL_OPTION        | "url"
+        "branchName"     | GITHUB_BRANCH_NAME_OPTION     | "branch"
+        extensionName = "github"
+    }
+
 }

--- a/src/main/groovy/wooga/gradle/github/base/GithubBasePlugin.groovy
+++ b/src/main/groovy/wooga/gradle/github/base/GithubBasePlugin.groovy
@@ -67,11 +67,11 @@ class GithubBasePlugin implements Plugin<Project> {
 
         extension.repositoryName.set(project.provider{
             project.properties.get(GithubBasePluginConvention.GITHUB_REPOSITORY_NAME_OPTION)?.toString()
-        }.orElse(repoInfo.repositoryNameProviderFromLocalGit()))
+        }.orElse(repoInfo.repositoryNameFromLocalGit))
 
         extension.branchName.set(project.provider {
             project.properties.get(GithubBasePluginConvention.GITHUB_BRANCH_NAME_OPTION)?.toString()
-        }.orElse(repoInfo.branchNameProviderFromLocalGit()))
+        }.orElse(repoInfo.branchNameFromLocalGit))
 
         project.tasks.withType(AbstractGithubTask).configureEach { task ->
             task.baseUrl.set(extension.baseUrl)

--- a/src/main/groovy/wooga/gradle/github/base/GithubBasePluginConvention.groovy
+++ b/src/main/groovy/wooga/gradle/github/base/GithubBasePluginConvention.groovy
@@ -55,4 +55,11 @@ class GithubBasePluginConvention {
      * @see GithubSpec#getBaseUrl()
      */
     static final String GITHUB_BASE_URL_OPTION = "github.baseUrl"
+
+    /**
+     * Gradle property name to set the default value for {@code branchName}.
+     * @value "github.branchName"
+     * @see GithubSpec#getBranchName()
+     */
+    static final String GITHUB_BRANCH_NAME_OPTION = "github.branch.name"
 }

--- a/src/main/groovy/wooga/gradle/github/base/GithubSpec.groovy
+++ b/src/main/groovy/wooga/gradle/github/base/GithubSpec.groovy
@@ -131,8 +131,7 @@ interface GithubSpec {
      * Sets the github access token.
      *
      * @param token the token. Must not be {@code Null} or {@code empty}
-     * @return this
-     * @throws IllegalArgumentException
+     * @return this* @throws IllegalArgumentException
      */
     void setToken(Provider<String> token)
 
@@ -149,4 +148,23 @@ interface GithubSpec {
      * @throws IOException if no credentials are found
      */
     Provider<GitHub> getClientProvider()
+
+    /**
+     * Returns the current git branch. Default value is in order of precedence:
+     * <ul>
+     *     <li>current branch's remote branch</li>
+     *     <li>current branch</li>
+     * </ul>
+     *
+     * <p>
+     * The value can also be set via gradle properties.
+     * The precedence order is:
+     * <ul>
+     *    <li><b>direct parameter in build.gradle code</b>
+     *    <li><b>gradle properties</b>
+     * </ul>
+     * @return the current branch name. May be {@code Null} if there is no set up git repository
+     * @see GithubBasePluginConvention#GITHUB_BRANCH_NAME_OPTION
+     */
+    Provider<String> getBranchName()
 }

--- a/src/main/groovy/wooga/gradle/github/base/internal/DefaultGithubPluginExtension.groovy
+++ b/src/main/groovy/wooga/gradle/github/base/internal/DefaultGithubPluginExtension.groovy
@@ -55,6 +55,7 @@ class DefaultGithubPluginExtension implements GithubPluginExtension {
     void setToken(Provider<String> token) {
         this.token.set(token)
     }
+
     @Override @Internal
     Provider<GitHub> getClientProvider() {
         return GithubClientFactory.clientProvider(username, password, token).
@@ -62,6 +63,8 @@ class DefaultGithubPluginExtension implements GithubPluginExtension {
           throw new IOException("could not find valid credentials for github client")
         })
     }
+
+    final Property<String> branchName
 
     private final Project project
 
@@ -73,5 +76,6 @@ class DefaultGithubPluginExtension implements GithubPluginExtension {
         username = project.objects.property(String)
         password = project.objects.property(String)
         token = project.objects.property(String)
+        branchName = project.objects.property(String)
     }
 }

--- a/src/main/groovy/wooga/gradle/github/base/internal/GithubClientFactory.groovy
+++ b/src/main/groovy/wooga/gradle/github/base/internal/GithubClientFactory.groovy
@@ -15,11 +15,11 @@ class GithubClientFactory {
         Provider hasCredsProvider = username.orElse(password).orElse(token).orElse("").
         map({
             return it == "" && !hasExternalCredentials()? null : true
-        }.memoize())
+        })
         return hasCredsProvider.map({
             return new GithubClientFactory().
                     createGithubClient(username.getOrNull(), password.getOrNull(), token.getOrNull())
-        }.memoize())
+        })
     }
 
     private static boolean hasExternalCredentials() {

--- a/src/main/groovy/wooga/gradle/github/base/internal/RepositoryInfo.groovy
+++ b/src/main/groovy/wooga/gradle/github/base/internal/RepositoryInfo.groovy
@@ -18,7 +18,7 @@ class RepositoryInfo {
         this.git = git
     }
 
-    Provider<String> repositoryNameProviderFromLocalGit() {
+    Provider<String> getRepositoryNameFromLocalGit() {
         return project.provider {
             git.remote.list().find {it.name == DEFAULT_REMOTE}?: null
         }.map{remote ->
@@ -29,7 +29,7 @@ class RepositoryInfo {
         }
     }
 
-    Provider<String> branchNameProviderFromLocalGit() {
+    Provider<String> getBranchNameFromLocalGit() {
         def currentBranch = git.branch.current()
         return project.provider { currentBranch.trackingBranch }.
                         orElse(currentBranch).

--- a/src/main/groovy/wooga/gradle/github/base/internal/RepositoryInfo.groovy
+++ b/src/main/groovy/wooga/gradle/github/base/internal/RepositoryInfo.groovy
@@ -1,0 +1,38 @@
+package wooga.gradle.github.base.internal
+
+
+import org.ajoberstar.grgit.Grgit
+import org.gradle.api.Project
+import org.gradle.api.provider.Provider
+
+class RepositoryInfo {
+
+    private static final String DOMAIN = "github.com"
+    private static final String DEFAULT_REMOTE = "origin"
+
+    final Project project
+    final Grgit git
+
+    RepositoryInfo(Project project, Grgit git) {
+        this.project = project
+        this.git = git
+    }
+
+    Provider<String> repositoryNameProviderFromLocalGit() {
+        return project.provider {
+            git.remote.list().find {it.name == DEFAULT_REMOTE}?: null
+        }.map{remote ->
+            def remoteURL = remote.url
+            def domainIndex = remoteURL.indexOf(DOMAIN)
+            def urlAfterDomain = remoteURL.substring(domainIndex + DOMAIN.length() + 1)
+            return urlAfterDomain.replace(".git", "")
+        }
+    }
+
+    Provider<String> branchNameProviderFromLocalGit() {
+        def currentBranch = git.branch.current()
+        return project.provider { currentBranch.trackingBranch }.
+                        orElse(currentBranch).
+                        map {it.name }
+    }
+}

--- a/src/main/groovy/wooga/gradle/github/base/tasks/internal/AbstractGithubTask.groovy
+++ b/src/main/groovy/wooga/gradle/github/base/tasks/internal/AbstractGithubTask.groovy
@@ -52,7 +52,7 @@ abstract class AbstractGithubTask<T extends AbstractGithubTask> extends Conventi
 
         repositoryName.set(name)
     }
-    
+
     @Optional
     private final Property<String> baseUrl
 
@@ -66,7 +66,7 @@ abstract class AbstractGithubTask<T extends AbstractGithubTask> extends Conventi
     void setBaseUrl(Provider<String> value) {
         baseUrl.set(value)
     }
-    
+
     @Optional
     private final Property<String> username
 
@@ -117,6 +117,14 @@ abstract class AbstractGithubTask<T extends AbstractGithubTask> extends Conventi
         clientProvider
     }
 
+    protected final Property<String> branchName
+
+    @Internal
+    @Override
+    Property<String> getBranchName() {
+        return branchName
+    }
+
     private final Class<T> taskType
 
     AbstractGithubTask(Class<T> taskType) {
@@ -129,6 +137,7 @@ abstract class AbstractGithubTask<T extends AbstractGithubTask> extends Conventi
         token = project.objects.property(String)
         clientProvider = project.objects.property(GitHub)
         clientProvider.set(GithubClientFactory.clientProvider(username, password, token))
+        branchName = project.objects.property(String)
     }
 
     @Internal

--- a/src/test/groovy/wooga/gradle/github/base/internal/RepositoryInfoSpec.groovy
+++ b/src/test/groovy/wooga/gradle/github/base/internal/RepositoryInfoSpec.groovy
@@ -46,9 +46,21 @@ class RepositoryInfoSpec extends ProjectSpec {
         !repoName.present
     }
 
+    def "gets empty providers if there is no local git repository"(){
+        given: "a gradle project"
+        and: "without local git"
+
+        when: "getting repository name form repository info"
+        def repoInfo = new RepositoryInfo(project, null as Grgit)
+
+        then:
+        !repoInfo.repositoryNameFromLocalGit.present
+        !repoInfo.branchNameFromLocalGit.present
+    }
+
     @Unroll
     def "creates repository info with expected branch"() {
-        given: "grgit installation"
+        given: "git installation"
         def git = mockedGrgitOnBranch(localBranch, trackingBranch)
 
         when:
@@ -62,11 +74,10 @@ class RepositoryInfoSpec extends ProjectSpec {
         where:
         localBranch | trackingBranch | expBranch
         "branch"    | null           | "branch"
-        null        | "tracking"     | "tracking"
         "branch"    | "tracking"     | "tracking"
     }
 
-    def mockedGrgitOnBranch(String currentBranchName, String currentTrackingBranchName = null,
+    def mockedGrgitOnBranch(String currentBranchName, String currentTrackingBranchName,
                             String remoteURL = "github.com:cmp/repo") {
         def gitMock = GroovyMock(Grgit)
 

--- a/src/test/groovy/wooga/gradle/github/base/internal/RepositoryInfoSpec.groovy
+++ b/src/test/groovy/wooga/gradle/github/base/internal/RepositoryInfoSpec.groovy
@@ -1,0 +1,93 @@
+package wooga.gradle.github.base.internal
+
+import nebula.test.ProjectSpec
+import org.ajoberstar.grgit.Branch
+import org.ajoberstar.grgit.Grgit
+import org.ajoberstar.grgit.Remote
+import org.ajoberstar.grgit.service.BranchService
+import org.ajoberstar.grgit.service.RemoteService
+import spock.lang.Unroll
+
+class RepositoryInfoSpec extends ProjectSpec {
+
+    @Unroll("gets repository name based on local git 'origin' remote url #remoteURL")
+    def "gets repository name based on local git 'origin' remote"() {
+        given: "a gradle project"
+        and: "a local git with set 'origin' remote"
+        def git = Grgit.init(dir: project.projectDir)
+        git.remote.add(name: "origin", url: remoteURL, pushUrl: remoteURL)
+
+
+        when: "creating new repository info"
+        def repoInfo = new RepositoryInfo(project, git)
+        def repoName = repoInfo.repositoryNameFromLocalGit
+
+        then:
+        repoName.present
+        repoName.get() == expectedRepositoryName
+
+        where:
+        remoteURL                              | expectedRepositoryName
+        "https://github.com/user/repo.git"     | "user/repo"
+        "https://www.github.com/user/repo.git" | "user/repo"
+        "git@github.com:user/repo.git"         | "user/repo"
+    }
+
+    def "gets empty repository name provider if there is no local git 'origin' remote"(){
+        given: "a gradle project"
+        and: "a local git without set 'origin' remote"
+        def git = Grgit.init(dir: project.projectDir)
+
+        when: "getting repository name form repository info"
+        def repoInfo = new RepositoryInfo(project, git)
+        def repoName = repoInfo.repositoryNameFromLocalGit
+
+        then:
+        !repoName.present
+    }
+
+    @Unroll
+    def "creates repository info with expected branch"() {
+        given: "grgit installation"
+        def git = mockedGrgitOnBranch(localBranch, trackingBranch)
+
+        when:
+        def infoFactory = new RepositoryInfo(project, git)
+        def infoProvider = infoFactory.branchNameFromLocalGit
+
+        then:
+        infoProvider.present
+        infoProvider.get() == expBranch
+
+        where:
+        localBranch | trackingBranch | expBranch
+        "branch"    | null           | "branch"
+        null        | "tracking"     | "tracking"
+        "branch"    | "tracking"     | "tracking"
+    }
+
+    def mockedGrgitOnBranch(String currentBranchName, String currentTrackingBranchName = null,
+                            String remoteURL = "github.com:cmp/repo") {
+        def gitMock = GroovyMock(Grgit)
+
+        def branchService = GroovyMock(BranchService)
+        def branchMock = GroovyMock(Branch)
+        gitMock.branch >> branchService
+        branchService.current() >> branchMock
+        branchMock.name >> currentBranchName
+        if (currentTrackingBranchName) {
+            def trackingBranch = GroovyMock(Branch)
+            trackingBranch.name >> currentTrackingBranchName
+            branchMock.trackingBranch >> trackingBranch
+        }
+
+        def remoteService = GroovyMock(RemoteService)
+        def remoteMock = GroovyMock(Remote)
+        gitMock.remote >> remoteService
+        remoteMock.url >> remoteURL
+        remoteService.list() >> [remoteMock]
+
+        return gitMock
+    }
+
+}


### PR DESCRIPTION
## Description
Adds the `branchName` property to the extension, which is fecthed from the current git branch tracking branch name, and if it does not have one, from the current branch name itself. As for this we need to use GrGit in this plugin, now the `repositoryName` is fetched automatically by default, from local git repository `origin` remote. 

If there is no local git avaliable, both branchName and repositoryName will default to empty providers.

## Changes
* ![ADD] `branchName` property to extension and tasks
* ![IMPROVE] `repositoryName` property default now is being fetched from local git `origin` remote.


[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:http://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:http://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:http://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://resources.atlas.wooga.com/icons/icon_webGL.svg "Web:GL"
