### PR TITLE
Improve tests by throttling API calls

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,7 +41,7 @@ github {
 }
 
 dependencies {
-    implementation 'org.kohsuke:github-api:1.131'
+    implementation 'org.kohsuke:github-api:1.133'
     implementation 'org.zeroturnaround:zt-zip:1.14'
     implementation 'org.apache.tika:tika-core:1.24.1'
 
@@ -49,7 +49,11 @@ dependencies {
         exclude group: "org.codehaus.groovy", module: "groovy-all"
     }
 
-    testImplementation('com.wooga.spock.extensions:spock-github-extension:0.1.2') {
+    testImplementation('com.wooga.spock.extensions:spock-github-extension:0.2.0') {
         exclude group: "org.codehaus.groovy", module: "groovy-all"
     }
+}
+
+repositories {
+    mavenCentral()
 }

--- a/src/integrationTest/groovy/wooga/gradle/github/GithubIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/github/GithubIntegrationSpec.groovy
@@ -166,7 +166,7 @@ class GithubIntegrationSpec extends GithubPublishIntegrationWithDefaultAuth {
             return code()
         } catch(IOException e) {
             if(retries > 0) {
-                sleep(1000)
+                throttle()
                 return retry(retries-1, code)
             } else {
                 throw e

--- a/src/integrationTest/groovy/wooga/gradle/github/GithubPublishAssetsIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/github/GithubPublishAssetsIntegrationSpec.groovy
@@ -255,6 +255,7 @@ class GithubPublishAssetsIntegrationSpec extends GithubPublishIntegrationWithDef
         """
 
         when:
+        throttle()
         def result = runTasksWithFailure("testPublish")
 
         then:
@@ -304,6 +305,7 @@ class GithubPublishAssetsIntegrationSpec extends GithubPublishIntegrationWithDef
         """
 
         when:
+        throttle()
         def result = runTasksWithFailure("testPublish")
 
         then:
@@ -353,6 +355,7 @@ class GithubPublishAssetsIntegrationSpec extends GithubPublishIntegrationWithDef
         """
 
         when:
+        throttle()
         def result = runTasksWithFailure("testPublish")
 
         then:

--- a/src/integrationTest/groovy/wooga/gradle/github/GithubPublishIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/github/GithubPublishIntegrationSpec.groovy
@@ -166,6 +166,7 @@ class GithubPublishIntegrationSpec extends GithubPublishIntegrationWithDefaultAu
 
         when:
         runTasksSuccessfully("testPublish")
+        throttle()
 
         then:
         def release = getRelease(tagName)

--- a/src/integrationTest/groovy/wooga/gradle/github/IntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/github/IntegrationSpec.groovy
@@ -41,6 +41,10 @@ class IntegrationSpec extends nebula.test.IntegrationSpec {
             fork = true
         }
     }
+    
+    static throttle() {
+        sleep(1000)
+    }
 
     Boolean outputContains(ExecutionResult result, String message) {
         result.standardOutput.contains(message) || result.standardError.contains(message)

--- a/src/integrationTest/groovy/wooga/gradle/github/tasks/GithubPublishTaskIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/github/tasks/GithubPublishTaskIntegrationSpec.groovy
@@ -182,6 +182,7 @@ class GithubPublishTaskIntegrationSpec extends AbstractGithubTaskIntegrationSpec
         result.success != expectedFailure
 
         if(result.success) {
+            throttle()
             assert hasRelease(tagName)
             def release = getRelease(tagName)
             assert release.body == releaseBody


### PR DESCRIPTION
## Description

Our integration tests against the github API are very flaky. This patch tries to add a not so smart workaround to make the tests more robust. Looking at the failing tests
my feeling is that some resources are not fully created on the github side. So I added some forced stops to make sure github has created repos/releases/assets etc are setup correctly.

## Changes

* ![IMPROVE] test by throttling API calls


[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:http://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:http://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:http://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://resources.atlas.wooga.com/icons/icon_webGL.svg "Web:GL"
