### PR TITLE
Fix Gradle 7 compatibility

### DIFF
--- a/src/main/groovy/wooga/gradle/github/publish/tasks/GithubPublish.groovy
+++ b/src/main/groovy/wooga/gradle/github/publish/tasks/GithubPublish.groovy
@@ -21,9 +21,7 @@ import groovy.io.FileType
 import groovy.json.JsonSlurper
 import org.apache.commons.io.FileUtils
 import org.gradle.api.Action
-import org.gradle.api.Buildable
 import org.gradle.api.GradleException
-import org.gradle.api.Task
 import org.gradle.api.file.CopySpec
 import org.gradle.api.file.FileTreeElement
 import org.gradle.api.logging.Logger
@@ -32,20 +30,17 @@ import org.gradle.api.provider.Property
 import org.gradle.api.provider.Provider
 import org.gradle.api.specs.Spec
 import org.gradle.api.specs.Specs
-import org.gradle.api.tasks.Input
-import org.gradle.api.tasks.Optional
-import org.gradle.api.tasks.TaskAction
-import org.gradle.api.tasks.WorkResult
+import org.gradle.api.tasks.*
 import org.gradle.util.ConfigureUtil
-import org.kohsuke.github.*
+import org.kohsuke.github.GHAsset
+import org.kohsuke.github.GHRelease
+import org.kohsuke.github.GHRepository
+import org.kohsuke.github.HttpException
 import org.zeroturnaround.zip.ZipUtil
 import wooga.gradle.github.base.tasks.internal.AbstractGithubTask
 import wooga.gradle.github.publish.GithubPublishSpec
-import wooga.gradle.github.publish.PublishBodyStrategy
 import wooga.gradle.github.publish.PublishMethod
 import wooga.gradle.github.publish.internal.*
-
-import java.util.concurrent.Callable
 
 /**
  * Publish a Github release with or without provided assets.
@@ -56,7 +51,8 @@ import java.util.concurrent.Callable
  * Example:
  * <pre>
  * {@code
- *     githubPublish {*         targetCommitish = "master"
+ *     githubPublish {
+ *         targetCommitish = "master"
  *         tagName = project.version
  *         releaseName = project.version
  *         body = "Release XYZ"
@@ -64,7 +60,8 @@ import java.util.concurrent.Callable
  *         draft = false
  *         publishMethod = "create"
  *         from(file('build/output'))
- *}*}
+ *     }
+ *}
  */
 class GithubPublish extends AbstractGithubTask implements GithubPublishSpec {
 
@@ -186,6 +183,7 @@ class GithubPublish extends AbstractGithubTask implements GithubPublishSpec {
         publishMethod = project.objects.property(PublishMethod)
     }
 
+    @OutputDirectory
     File getDestinationDir() {
         assetCollectDirectory
     }
@@ -439,6 +437,7 @@ class GithubPublish extends AbstractGithubTask implements GithubPublishSpec {
      * @return The include patterns. Returns an empty set when there are no include patterns.
      */
     @Override
+    @Input
     Set<String> getIncludes() {
         assetsCopySpec.getIncludes()
     }
@@ -449,6 +448,7 @@ class GithubPublish extends AbstractGithubTask implements GithubPublishSpec {
      * @return The include patterns. Returns an empty set when there are no include patterns.
      */
     @Override
+    @Input
     Set<String> getExcludes() {
         assetsCopySpec.getExcludes()
     }


### PR DESCRIPTION
## Description

I had to reopen issue #55 because we still had three properties in `GithubPublish` tasks without proper input/output declaration.

resolves #55

## Changes

* ![FIX] ![GRADLE] 7 compatibility


[NEW]:      https://resources.atlas.wooga.com/icons/icon_new.svg "New"
[ADD]:      https://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:  https://resources.atlas.wooga.com/icons/icon_improve.svg "Improve"
[CHANGE]:   https://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:      https://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:   https://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:    https://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:   https://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:      https://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:  https://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:    https://resources.atlas.wooga.com/icons/icon_webGL.svg "WebGL"
[GRADLE]:   https://resources.atlas.wooga.com/icons/icon_gradle.svg "GRADLE"
[UNITY]:    https://resources.atlas.wooga.com/icons/icon_unity.svg "Unity"
[LINUX]:    https://resources.atlas.wooga.com/icons/icon_linux.svg "Linux"
[WIN]:      https://resources.atlas.wooga.com/icons/icon_windows.svg "Windows"
[MACOS]:    https://resources.atlas.wooga.com/icons/icon_iOS.svg "macOS"
