### PR TITLE
Repository info returns empty provider if origin isn't github

### DIFF
--- a/src/main/groovy/wooga/gradle/github/base/internal/RepositoryInfo.groovy
+++ b/src/main/groovy/wooga/gradle/github/base/internal/RepositoryInfo.groovy
@@ -7,7 +7,7 @@ import org.gradle.api.provider.Provider
 
 class RepositoryInfo {
 
-    private static final String DOMAIN = "github.com"
+    private static final String GITHUB_DOMAIN = "github.com"
     private static final String DEFAULT_REMOTE = "origin"
 
     final Project project
@@ -24,11 +24,11 @@ class RepositoryInfo {
 
     Provider<String> getRepositoryNameFromLocalGit() {
         return grgitProvider.map { git ->
-            git.remote.list().find {it.name == DEFAULT_REMOTE}?: null
+            git.remote.list().find {it.name == DEFAULT_REMOTE && it.url.contains(GITHUB_DOMAIN)}?: null
         }.map{remote ->
             def remoteURL = remote.url
-            def domainIndex = remoteURL.indexOf(DOMAIN)
-            def urlAfterDomain = remoteURL.substring(domainIndex + DOMAIN.length() + 1)
+            def domainIndex = remoteURL.indexOf(GITHUB_DOMAIN)
+            def urlAfterDomain = remoteURL.substring(domainIndex + GITHUB_DOMAIN.length() + 1)
             return urlAfterDomain.replace(".git", "")
         }
     }

--- a/src/test/groovy/wooga/gradle/github/base/internal/RepositoryInfoSpec.groovy
+++ b/src/test/groovy/wooga/gradle/github/base/internal/RepositoryInfoSpec.groovy
@@ -58,6 +58,23 @@ class RepositoryInfoSpec extends ProjectSpec {
         !repoInfo.branchNameFromLocalGit.present
     }
 
+
+    def "gets empty repository name if current git remote is not from github.com"(){
+        given: "a gradle project"
+        and: "a local git with set 'origin' remote not from github.com"
+        def remoteURL = "https://bitbucket.org/repo"
+        def git = Grgit.init(dir: project.projectDir)
+        git.remote.add(name: "origin", url: remoteURL, pushUrl: remoteURL)
+
+
+        when: "getting repository name form repository info"
+        def repoInfo = new RepositoryInfo(project, git)
+
+        then:
+        !repoInfo.repositoryNameFromLocalGit.present
+        repoInfo.branchNameFromLocalGit.present
+    }
+
     @Unroll
     def "creates repository info with expected branch"() {
         given: "git installation"


### PR DESCRIPTION
## Description
Fixed issue in  `RepositoryInfo.getRepositoryNameFromLocalGit()` where gibberish was returned if git origin existed and wasn't from github.com. Now we check for github's domain presence in the provider.

Links to issue #99.

## Changes
* ![FIX] `RepositoryInfo.getRepositoryNameFromLocalGit()` provider now its empty when git origin isn't from github.



[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:http://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:http://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:http://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://resources.atlas.wooga.com/icons/icon_webGL.svg "Web:GL"
