### PR TITLE
Fix wrong dependency scope of github-api

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -51,7 +51,7 @@ cveHandler {
 }
 
 dependencies {
-    implementation 'org.kohsuke:github-api:1.135'
+    api 'org.kohsuke:github-api:1.135'
     implementation 'org.zeroturnaround:zt-zip:1.14'
     implementation 'org.apache.tika:tika-core:1.24.1'
     implementation 'org.ajoberstar.grgit:grgit-core:[4.1.1,5)'


### PR DESCRIPTION
## Description
`org.kohsuke.github.GitHub` and `org.kohsuke.github.GHRepository` (at least) are part of the public API,
to be used in generic custom `Github`-typed tasks, so github-api should be an `api` dependency, not `implementation`.

## Changes
* ![FIX] Fix wrong dependency scope of gradle-commons

[FIX]:      https://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"